### PR TITLE
Remove Try Catch from `muzzle-routes`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -132,6 +132,12 @@
         "@types/node": "*"
       }
     },
+    "@types/lolex": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/lolex/-/lolex-3.1.1.tgz",
+      "integrity": "sha512-NU2qVtKxbt4IBvjEOW1QeUnV6KGUF6hpgJyvwZt3JrXe2qmwQF0+BiazQw+iFy9qL5ie+QHOxTzXkcvJUEh76g==",
+      "dev": true
+    },
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
@@ -2985,6 +2991,12 @@
           }
         }
       }
+    },
+    "lolex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
+      "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
+      "dev": true
     },
     "lowercase-keys": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "license": "ISC",
   "dependencies": {
     "@slack/web-api": "^5.0.1",
-    "@types/express": "^4.16.1",
     "axios": "^0.18.1",
     "body-parser": "^1.18.3",
     "express": "^4.16.4",
@@ -27,11 +26,14 @@
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
+    "@types/express": "^4.16.1",
+    "@types/lolex": "^3.1.1",
     "@types/mocha": "^5.2.6",
     "@types/node": "^12.0.2",
     "chai": "^4.2.0",
     "husky": "^2.3.0",
     "lint-staged": "^8.1.7",
+    "lolex": "^4.1.0",
     "mocha": "^6.1.4",
     "nodemon": "^1.19.0",
     "prettier": "1.17.1",

--- a/src/routes/muzzle-route.ts
+++ b/src/routes/muzzle-route.ts
@@ -51,13 +51,14 @@ muzzleRoutes.post("/muzzle/handle", (req: Request, res: Response) => {
   res.send({ challenge: request.challenge });
 });
 
-muzzleRoutes.post("/muzzle", (req: Request, res: Response) => {
+muzzleRoutes.post("/muzzle", async (req: Request, res: Response) => {
   const request: ISlashCommandRequest = req.body;
   const userId: string = getUserId(request.text);
   const userName: string = getUserName(request.text);
-  try {
-    res.send(addUserToMuzzled(userId, userName, request.user_id));
-  } catch (e) {
-    res.send(e.message);
-  }
+  const results = await addUserToMuzzled(
+    userId,
+    userName,
+    request.user_id
+  ).catch(e => res.send(e));
+  res.send(results);
 });

--- a/src/routes/muzzle-route.ts
+++ b/src/routes/muzzle-route.ts
@@ -60,5 +60,7 @@ muzzleRoutes.post("/muzzle", async (req: Request, res: Response) => {
     userName,
     request.user_id
   ).catch(e => res.send(e));
-  res.send(results);
+  if (results) {
+    res.send(results);
+  }
 });

--- a/src/utils/muzzle/muzzle-utils.spec.ts
+++ b/src/utils/muzzle/muzzle-utils.spec.ts
@@ -57,7 +57,7 @@ describe("muzzle-utils", () => {
         );
       });
 
-      it("should throw an error if a user tries to muzzle an already muzzled user", async () => {
+      it("should reject if a user tries to muzzle an already muzzled user", async () => {
         await addUserToMuzzled(
           testData.user,
           testData.friendlyName,
@@ -73,7 +73,7 @@ describe("muzzle-utils", () => {
         });
       });
 
-      it("should throw an error if a requestor tries to muzzle someone while the requestor is muzzled", async () => {
+      it("should reject if a requestor tries to muzzle someone while the requestor is muzzled", async () => {
         await addUserToMuzzled(
           testData.user,
           testData.friendlyName,

--- a/src/utils/muzzle/muzzle-utils.spec.ts
+++ b/src/utils/muzzle/muzzle-utils.spec.ts
@@ -29,6 +29,10 @@ describe("muzzle-utils", () => {
     clock.reset();
   });
 
+  after(() => {
+    clock.uninstall();
+  });
+
   describe("addUserToMuzzled()", () => {
     describe("muzzled", () => {
       it("should add a user to the muzzled map", () => {

--- a/src/utils/muzzle/muzzle-utils.spec.ts
+++ b/src/utils/muzzle/muzzle-utils.spec.ts
@@ -46,36 +46,38 @@ describe("muzzle-utils", () => {
         );
       });
 
-      it("should throw an error if a user tries to muzzle an already muzzled user", () => {
-        addUserToMuzzled(
+      it("should throw an error if a user tries to muzzle an already muzzled user", async () => {
+        await addUserToMuzzled(
           testData.user,
           testData.friendlyName,
           testData.requestor
         );
         expect(muzzled.has(testData.user)).to.equal(true);
-        expect(() =>
-          addUserToMuzzled(
-            testData.user,
-            testData.friendlyName,
-            testData.requestor
-          )
-        ).to.throw(`${testData.friendlyName} is already muzzled!`);
+        await addUserToMuzzled(
+          testData.user,
+          testData.friendlyName,
+          testData.requestor
+        ).catch(e => {
+          expect(e).to.equal(`${testData.friendlyName} is already muzzled!`);
+        });
       });
 
-      it("should throw an error if a requestor tries to muzzle someone while the requestor is muzzled", () => {
-        addUserToMuzzled(
+      it("should throw an error if a requestor tries to muzzle someone while the requestor is muzzled", async () => {
+        await addUserToMuzzled(
           testData.user,
           testData.friendlyName,
           testData.requestor
         );
         expect(muzzled.has(testData.user)).to.equal(true);
-        expect(() =>
-          addUserToMuzzled(
-            testData.requestor,
-            testData.friendlyName,
-            testData.user
-          )
-        ).to.throw(`You can't muzzle someone if you are already muzzled!`);
+        await addUserToMuzzled(
+          testData.requestor,
+          testData.friendlyName,
+          testData.user
+        ).catch(e => {
+          expect(e).to.equal(
+            `You can't muzzle someone if you are already muzzled!`
+          );
+        });
       });
     });
 
@@ -116,25 +118,25 @@ describe("muzzle-utils", () => {
         expect(muzzlers.get(testData.requestor)!.muzzleCount).to.equal(2);
       });
 
-      it("should prevent a requestor from muzzling on their third count", () => {
-        addUserToMuzzled(
+      it("should prevent a requestor from muzzling on their third count", async () => {
+        await addUserToMuzzled(
           testData.user,
           testData.friendlyName,
           testData.requestor
         );
-        addUserToMuzzled(
+        await addUserToMuzzled(
           testData.user2,
           testData.friendlyName,
           testData.requestor
         );
-        expect(() =>
-          addUserToMuzzled(
-            testData.user3,
-            testData.friendlyName,
-            testData.requestor
+        await addUserToMuzzled(
+          testData.user3,
+          testData.friendlyName,
+          testData.requestor
+        ).catch(e =>
+          expect(e).to.equal(
+            `You're doing that too much. Only ${MAX_MUZZLES} muzzles are allowed per hour.`
           )
-        ).to.throw(
-          `You're doing that too much. Only ${MAX_MUZZLES} muzzles are allowed per hour.`
         );
       });
     });

--- a/src/utils/muzzle/muzzle-utils.spec.ts
+++ b/src/utils/muzzle/muzzle-utils.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import * as lolex from "lolex";
 import {
   addUserToMuzzled,
   MAX_MUZZLES,
@@ -17,9 +18,15 @@ describe("muzzle-utils", () => {
     requestor: "test-requestor"
   };
 
+  const clock = lolex.install();
+
   beforeEach(() => {
     muzzled.clear();
     muzzlers.clear();
+  });
+
+  afterEach(() => {
+    clock.reset();
   });
 
   describe("addUserToMuzzled()", () => {

--- a/src/utils/muzzle/muzzle-utils.ts
+++ b/src/utils/muzzle/muzzle-utils.ts
@@ -1,7 +1,7 @@
 import { IMuzzled, IMuzzler } from "../../shared/models/muzzle/muzzle-models";
 // Store for the muzzled users.
 export const muzzled: Map<string, IMuzzled> = new Map();
-// STore for people who are muzzling others.
+// Store for people who are muzzling others.
 export const muzzlers: Map<string, IMuzzler> = new Map();
 
 // Time period in which a user must wait before making more muzzles.
@@ -28,72 +28,78 @@ export function addUserToMuzzled(
   friendlyMuzzle: string,
   requestor: string
 ) {
-  const timeToMuzzle = Math.floor(Math.random() * (180000 - 30000 + 1) + 30000);
-  const minutes = Math.floor(timeToMuzzle / 60000);
-  const seconds = ((timeToMuzzle % 60000) / 1000).toFixed(0);
-  if (muzzled.has(toMuzzle)) {
-    console.error(
-      `${requestor} attempted to muzzle ${toMuzzle} but ${toMuzzle} is already muzzled.`
+  return new Promise((resolve, reject) => {
+    const timeToMuzzle = Math.floor(
+      Math.random() * (180000 - 30000 + 1) + 30000
     );
-    throw new Error(`${friendlyMuzzle} is already muzzled!`);
-  } else if (muzzled.has(requestor)) {
-    console.error(
-      `User: ${requestor} attempted to muzzle ${toMuzzle} but failed because requestor: ${requestor} is currently muzzled`
-    );
-    throw new Error(`You can't muzzle someone if you are already muzzled!`);
-  } else if (
-    muzzlers.has(requestor) &&
-    muzzlers.get(requestor)!.muzzleCount === MAX_MUZZLES
-  ) {
-    console.error(
-      `User: ${requestor} attempted to muzzle ${toMuzzle} but failed because requestor: ${requestor} has reached maximum muzzle of ${MAX_MUZZLES}`
-    );
-    throw new Error(
-      `You're doing that too much. Only ${MAX_MUZZLES} muzzles are allowed per hour.`
-    );
-  } else {
-    // Add a newly muzzled user.
-    muzzled.set(toMuzzle, {
-      suppressionCount: 0,
-      muzzledBy: requestor
-    });
-    const muzzleCount = muzzlers.has(requestor)
-      ? ++muzzlers.get(requestor)!.muzzleCount
-      : 1;
-    // Add requestor to muzzlers
-    muzzlers.set(requestor, {
-      muzzleCount,
-      muzzleCountRemover: setTimeout(
-        () => decrementMuzzleCount(requestor),
-        MAX_TIME_BETWEEN_MUZZLES
-      )
-    });
-
-    if (
+    const minutes = Math.floor(timeToMuzzle / 60000);
+    const seconds = ((timeToMuzzle % 60000) / 1000).toFixed(0);
+    if (muzzled.has(toMuzzle)) {
+      console.error(
+        `${requestor} attempted to muzzle ${toMuzzle} but ${toMuzzle} is already muzzled.`
+      );
+      reject(`${friendlyMuzzle} is already muzzled!`);
+    } else if (muzzled.has(requestor)) {
+      console.error(
+        `User: ${requestor} attempted to muzzle ${toMuzzle} but failed because requestor: ${requestor} is currently muzzled`
+      );
+      reject(`You can't muzzle someone if you are already muzzled!`);
+    } else if (
       muzzlers.has(requestor) &&
-      muzzlers.get(requestor)!.muzzleCountRemover
+      muzzlers.get(requestor)!.muzzleCount === MAX_MUZZLES
     ) {
-      const currentTimer = muzzlers.get(requestor)!.muzzleCountRemover;
-      clearTimeout(currentTimer as NodeJS.Timeout);
-      const removalFunction =
-        muzzlers.get(requestor)!.muzzleCount === MAX_MUZZLES
-          ? () => removeMuzzler(requestor)
-          : () => decrementMuzzleCount(requestor);
-      muzzlers.set(requestor, {
-        muzzleCount: muzzlers.get(requestor)!.muzzleCount,
-        muzzleCountRemover: setTimeout(removalFunction, MAX_MUZZLE_TIME)
+      console.error(
+        `User: ${requestor} attempted to muzzle ${toMuzzle} but failed because requestor: ${requestor} has reached maximum muzzle of ${MAX_MUZZLES}`
+      );
+      reject(
+        `You're doing that too much. Only ${MAX_MUZZLES} muzzles are allowed per hour.`
+      );
+    } else {
+      // Add a newly muzzled user.
+      muzzled.set(toMuzzle, {
+        suppressionCount: 0,
+        muzzledBy: requestor
       });
+      const muzzleCount = muzzlers.has(requestor)
+        ? ++muzzlers.get(requestor)!.muzzleCount
+        : 1;
+      // Add requestor to muzzlers
+      muzzlers.set(requestor, {
+        muzzleCount,
+        muzzleCountRemover: setTimeout(
+          () => decrementMuzzleCount(requestor),
+          MAX_TIME_BETWEEN_MUZZLES
+        )
+      });
+
+      if (
+        muzzlers.has(requestor) &&
+        muzzlers.get(requestor)!.muzzleCountRemover
+      ) {
+        const currentTimer = muzzlers.get(requestor)!.muzzleCountRemover;
+        clearTimeout(currentTimer as NodeJS.Timeout);
+        const removalFunction =
+          muzzlers.get(requestor)!.muzzleCount === MAX_MUZZLES
+            ? () => removeMuzzler(requestor)
+            : () => decrementMuzzleCount(requestor);
+        muzzlers.set(requestor, {
+          muzzleCount: muzzlers.get(requestor)!.muzzleCount,
+          muzzleCountRemover: setTimeout(removalFunction, MAX_MUZZLE_TIME)
+        });
+      }
+      console.log(
+        `${friendlyMuzzle} is now muzzled for ${timeToMuzzle} milliseconds`
+      );
+      setTimeout(() => removeMuzzle(toMuzzle), timeToMuzzle);
+      resolve(
+        `Succesfully muzzled ${friendlyMuzzle} for ${
+          +seconds === 60
+            ? minutes + 1 + "m00s"
+            : minutes + "m" + (+seconds < 10 ? "0" : "") + seconds + "s"
+        } minutes`
+      );
     }
-    console.log(
-      `${friendlyMuzzle} is now muzzled for ${timeToMuzzle} milliseconds`
-    );
-    setTimeout(() => removeMuzzle(toMuzzle), timeToMuzzle);
-    return `Succesfully muzzled ${friendlyMuzzle} for ${
-      +seconds === 60
-        ? minutes + 1 + "m00s"
-        : minutes + "m" + (+seconds < 10 ? "0" : "") + seconds + "s"
-    } minutes`;
-  }
+  });
 }
 
 export function decrementMuzzleCount(requestor: string) {


### PR DESCRIPTION
- Removes the try catch block from `muzzle-routes` in favor of `.catch` on `addUserToMuzzled`
- Updates tests to reflect changes to `addUserToMuzzled`
- Adds `lolex` dev-dependency to prevent tests from running due to outstanding timeouts