### PR TITLE
Report Service Fix

### DIFF
--- a/src/controllers/muzzle.controller.ts
+++ b/src/controllers/muzzle.controller.ts
@@ -22,6 +22,12 @@ const reportService = new ReportService();
 
 muzzleController.post("/muzzle/handle", (req: Request, res: Response) => {
   const request: IEventRequest = req.body;
+  const isNewUserAdded = request.type === "team_join";
+
+  if (isNewUserAdded) {
+    slackService.getAllUsers();
+  }
+
   const isUserMuzzled = muzzlePersistenceService.isUserMuzzled(
     request.event.user
   );

--- a/src/services/slack/slack.service.ts
+++ b/src/services/slack/slack.service.ts
@@ -94,9 +94,13 @@ export class SlackService {
    * Retrieves a list of all users.
    */
   public async getAllUsers() {
+    console.log("Retrieving new user list...");
     this.userList = (await this.web
       .getAllUsers()
-      .then(resp => resp.members as ISlackUser[])
+      .then(resp => {
+        console.log("New user list has been retrieved!");
+        return resp.members as ISlackUser[];
+      })
       .catch(e => {
         console.error("Failed to retrieve users", e);
         console.error("Retrying in 5 seconds");


### PR DESCRIPTION
- Adds a check to refresh the local cache of users when a new user is added to the workspace
- Fixes an issue in which the report service would encounter runtime errors when trying to generate reports for users who were not in the local cache.