### PR TITLE
Fix Expire Message and Other Counter Bugs

### DIFF
--- a/src/controllers/muzzle.controller.ts
+++ b/src/controllers/muzzle.controller.ts
@@ -147,6 +147,7 @@ muzzleController.post("/muzzle/handle", (req: Request, res: Response) => {
           request.event.user
         )} attempted to tag someone. Counter Muzzle increased by ${ABUSE_PENALTY_TIME}!`
       );
+      console.log(request.event);
       counterPersistenceService.addCounterMuzzleTime(
         request.event.user,
         ABUSE_PENALTY_TIME

--- a/src/services/counter/counter.persistence.service.ts
+++ b/src/services/counter/counter.persistence.service.ts
@@ -108,9 +108,8 @@ export class CounterPersistenceService {
 
   public async removeCounter(id: number, isUsed: boolean, channel?: string) {
     const counter = this.counters.get(id);
-
+    clearTimeout(counter!.removalFn);
     if (isUsed && channel) {
-      clearTimeout(counter!.removalFn);
       this.counters.delete(id);
       await this.setCounteredToTrue(id).catch(e =>
         console.error("Error during setCounteredToTrue", e)

--- a/src/services/counter/counter.service.ts
+++ b/src/services/counter/counter.service.ts
@@ -51,8 +51,8 @@ export class CounterService {
 
   public getCounterByRequestorAndUserId(requestorId: string, userId: string) {
     return this.counterPersistenceService.getCounterByRequestorAndUserId(
-      userId,
-      requestorId
+      requestorId,
+      userId
     );
   }
 

--- a/src/services/counter/counter.service.ts
+++ b/src/services/counter/counter.service.ts
@@ -36,7 +36,7 @@ export class CounterService {
         reject("You already have a counter for this user.");
       } else {
         await this.counterPersistenceService
-          .addCounter(requestorId, counteredId, this.removeCounter)
+          .addCounter(requestorId, counteredId)
           .then(() => {
             resolve(
               `Counter set for ${counterUserName} for the next ${getTimeString(
@@ -177,17 +177,6 @@ export class CounterService {
         }>! <@${
           counter!.counteredId
         }> has lost muzzle privileges for one hour and is muzzled for the next 5 minutes! :crossed_swords:`
-      );
-    } else {
-      this.counterPersistenceService.counterMuzzle(counter!.requestorId, id);
-      this.muzzlePersistenceService.removeMuzzlePrivileges(
-        counter!.requestorId
-      );
-      this.webService.sendMessage(
-        "#general",
-        `:flesh: <@${counter!.requestorId}> lives in fear of <@${
-          counter!.counteredId
-        }> and is now muzzled and has lost muzzle privileges for one hour. :flesh:`
       );
     }
   }

--- a/src/services/counter/counter.service.ts
+++ b/src/services/counter/counter.service.ts
@@ -172,9 +172,9 @@ export class CounterService {
       );
       this.webService.sendMessage(
         channel,
-        `:crossed_swords: $<@${
-          counter!.requestorId
-        }> successfully countered <@${counter!.counteredId}>! <@${
+        `:crossed_swords: <@${counter!.requestorId}> successfully countered <@${
+          counter!.counteredId
+        }>! <@${
           counter!.counteredId
         }> has lost muzzle privileges for one hour and is muzzled for the next 5 minutes! :crossed_swords:`
       );

--- a/src/services/counter/counter.service.ts
+++ b/src/services/counter/counter.service.ts
@@ -36,7 +36,7 @@ export class CounterService {
         reject("You already have a counter for this user.");
       } else {
         await this.counterPersistenceService
-          .addCounter(requestorId, counteredId, false)
+          .addCounter(requestorId, counteredId, this.removeCounter)
           .then(() => {
             resolve(
               `Counter set for ${counterUserName} for the next ${getTimeString(


### PR DESCRIPTION
- Fixes the expire message to remove a random `$`
- Fixes the expire message to fire on expiration
- Fixes the expire message to ONLY fire on expiration, not after a counter is successful
- Created a bit of an anti-pattern inside of `counter.persistence.service.ts` in order to make this work. This is technical debt that needs to be addressed in the future
- Added logs