### PR TITLE
feature/add increased backfire

### DIFF
--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -157,9 +157,6 @@ eventController.post('/muzzle/handle', async (req: Request, res: Response) => {
     const isUserCounterMuzzled = await counterPersistenceService.isCounterMuzzled(request.event.user);
     const isInHotAndNotBot = request.event.user !== 'ULG8SJRFF' && request.event.channel === 'C027YMYC5CJ';
     const isMuzzleBot = request.event.user === 'ULG8SJRFF';
-    console.log(request);
-    console.log(request.event);
-    // console.log(request.event?.blocks[0]);
     if (isNewUserAdded) {
       handleNewUserAdd();
     } else if (isNewChannelCreated) {

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -159,7 +159,7 @@ eventController.post('/muzzle/handle', async (req: Request, res: Response) => {
     const isMuzzleBot = request.event.user === 'ULG8SJRFF';
     console.log(request);
     console.log(request.event);
-    console.log(request.event.blocks[0]);
+    console.log(request.event?.blocks[0]);
     if (isNewUserAdded) {
       handleNewUserAdd();
     } else if (isNewChannelCreated) {

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -155,19 +155,19 @@ eventController.post('/muzzle/handle', async (req: Request, res: Response) => {
     const isUserBackfired = await backfirePersistenceService.isBackfire(request.event.user, request.team_id);
     // TO DO: Add teamId to this call once counterPersistenceService uses redis.
     const isUserCounterMuzzled = await counterPersistenceService.isCounterMuzzled(request.event.user);
-    const isInHotAndNotBot = request.event.user !== 'ULG8SJRFF' && request.event.channel === 'C027YMYC5CJ';
     const isMuzzleBot = request.event.user === 'ULG8SJRFF';
+    const isInHotAndNotBot = !isMuzzleBot && request.event.channel === 'C027YMYC5CJ';
     if (isNewUserAdded) {
       handleNewUserAdd();
     } else if (isNewChannelCreated) {
       handleNewChannelCreated();
-    } else if (isMuzzled && !isReaction && !isMuzzleBot) {
+    } else if (isMuzzled && !isReaction) {
       handleMuzzledMessage(request);
-    } else if (isUserBackfired && !isReaction && !isMuzzleBot) {
+    } else if (isUserBackfired && !isReaction) {
       handleBackfire(request);
-    } else if (isUserCounterMuzzled && !isReaction && !isMuzzleBot) {
+    } else if (isUserCounterMuzzled && !isReaction) {
       handleCounterMuzzle(request);
-    } else if ((await suppressorService.shouldBotMessageBeMuzzled(request)) && !isReaction && !isMuzzleBot) {
+    } else if ((await suppressorService.shouldBotMessageBeMuzzled(request)) && !isReaction) {
       handleBotMessage(request);
     } else if (isReaction) {
       handleReaction(request);

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -157,6 +157,8 @@ eventController.post('/muzzle/handle', async (req: Request, res: Response) => {
     const isUserCounterMuzzled = await counterPersistenceService.isCounterMuzzled(request.event.user);
     const isInHotAndNotBot = request.event.user !== 'ULG8SJRFF' && request.event.channel === 'C027YMYC5CJ';
     const isMuzzleBot = request.event.user === 'ULG8SJRFF';
+    console.log(request);
+    console.log(request.event);
     if (isNewUserAdded) {
       handleNewUserAdd();
     } else if (isNewChannelCreated) {

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -159,7 +159,7 @@ eventController.post('/muzzle/handle', async (req: Request, res: Response) => {
     const isMuzzleBot = request.event.user === 'ULG8SJRFF';
     console.log(request);
     console.log(request.event);
-    console.log(request.event?.blocks[0]);
+    // console.log(request.event?.blocks[0]);
     if (isNewUserAdded) {
       handleNewUserAdd();
     } else if (isNewChannelCreated) {

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -159,6 +159,7 @@ eventController.post('/muzzle/handle', async (req: Request, res: Response) => {
     const isMuzzleBot = request.event.user === 'ULG8SJRFF';
     console.log(request);
     console.log(request.event);
+    console.log(request.event.blocks[0]);
     if (isNewUserAdded) {
       handleNewUserAdd();
     } else if (isNewChannelCreated) {

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -156,17 +156,18 @@ eventController.post('/muzzle/handle', async (req: Request, res: Response) => {
     // TO DO: Add teamId to this call once counterPersistenceService uses redis.
     const isUserCounterMuzzled = await counterPersistenceService.isCounterMuzzled(request.event.user);
     const isInHotAndNotBot = request.event.user !== 'ULG8SJRFF' && request.event.channel === 'C027YMYC5CJ';
+    const isMuzzleBot = request.event.user === 'ULG8SJRFF';
     if (isNewUserAdded) {
       handleNewUserAdd();
     } else if (isNewChannelCreated) {
       handleNewChannelCreated();
-    } else if (isMuzzled && !isReaction) {
+    } else if (isMuzzled && !isReaction && !isMuzzleBot) {
       handleMuzzledMessage(request);
-    } else if (isUserBackfired && !isReaction) {
+    } else if (isUserBackfired && !isReaction && !isMuzzleBot) {
       handleBackfire(request);
-    } else if (isUserCounterMuzzled && !isReaction) {
+    } else if (isUserCounterMuzzled && !isReaction && !isMuzzleBot) {
       handleCounterMuzzle(request);
-    } else if ((await suppressorService.shouldBotMessageBeMuzzled(request)) && !isReaction) {
+    } else if ((await suppressorService.shouldBotMessageBeMuzzled(request)) && !isReaction && !isMuzzleBot) {
       handleBotMessage(request);
     } else if (isReaction) {
       handleReaction(request);

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ const connectToDb = async (): Promise<void> => {
     createConnection(options)
       .then(connection => {
         if (connection.isConnected) {
-          slackService.getAllUsers();
+          slackService.getAllUsers(true);
           slackService.getAndSaveAllChannels();
           console.log(`Connected to MySQL DB: ${options.database}`);
         } else {

--- a/src/services/muzzle/constants.ts
+++ b/src/services/muzzle/constants.ts
@@ -6,7 +6,9 @@ export const ABUSE_PENALTY_TIME = 300000;
 export const REPLACEMENT_TEXT = ['..mMm..', '..MICROSOFT..'];
 export const MAX_WORD_LENGTH = 10;
 export const USER_REGEX = /[<]@\w+/gm;
+export const MAX_TOTAL_MUZZLE_COUNT_LENGTH = 86400000;
 export enum MuzzleRedisTypeEnum {
   'Muzzled' = 'muzzled',
   'Requestor' = 'requestor',
+  'Muzzles' = 'muzzles',
 }

--- a/src/services/muzzle/constants.ts
+++ b/src/services/muzzle/constants.ts
@@ -6,7 +6,7 @@ export const ABUSE_PENALTY_TIME = 300000;
 export const REPLACEMENT_TEXT = ['..mMm..', '..MICROSOFT..'];
 export const MAX_WORD_LENGTH = 10;
 export const USER_REGEX = /[<]@\w+/gm;
-export const MAX_TOTAL_MUZZLE_COUNT_LENGTH = 86400000;
+export const MAX_TOTAL_MUZZLE_COUNT_LENGTH = 604800000;
 export enum MuzzleRedisTypeEnum {
   'Muzzled' = 'muzzled',
   'Requestor' = 'requestor',

--- a/src/services/muzzle/constants.ts
+++ b/src/services/muzzle/constants.ts
@@ -6,9 +6,7 @@ export const ABUSE_PENALTY_TIME = 300000;
 export const REPLACEMENT_TEXT = ['..mMm..', '..MICROSOFT..'];
 export const MAX_WORD_LENGTH = 10;
 export const USER_REGEX = /[<]@\w+/gm;
-export const MAX_TOTAL_MUZZLE_COUNT_LENGTH = 604800000;
 export enum MuzzleRedisTypeEnum {
   'Muzzled' = 'muzzled',
   'Requestor' = 'requestor',
-  'Muzzles' = 'muzzles',
 }

--- a/src/services/muzzle/muzzle-utilities.ts
+++ b/src/services/muzzle/muzzle-utilities.ts
@@ -35,8 +35,3 @@ export function getTimeString(time: number): string {
 export function isRandomEven(): boolean {
   return Math.floor(Math.random() * 2) % 2 === 0;
 }
-
-export function shouldBackfire(): boolean {
-  const chanceOfBackfire = 0.05;
-  return Math.random() <= chanceOfBackfire;
-}

--- a/src/services/muzzle/muzzle.persistence.service.ts
+++ b/src/services/muzzle/muzzle.persistence.service.ts
@@ -206,8 +206,6 @@ export class MuzzlePersistenceService {
 
   public getMuzzlesByTimePeriod(userId: string, teamId: string, start: string, end: string) {
     const query = `SELECT COUNT(*) as count FROM muzzle WHERE createdAt >= '${start}' AND createdAt < '${end}' AND teamId='${teamId}' AND requestorId='${userId}';`;
-    return getRepository(Muzzle)
-      .query(query)
-      .then(item => item.count);
+    return getRepository(Muzzle).query(query);
   }
 }

--- a/src/services/muzzle/muzzle.persistence.service.ts
+++ b/src/services/muzzle/muzzle.persistence.service.ts
@@ -206,6 +206,8 @@ export class MuzzlePersistenceService {
 
   public getMuzzlesByTimePeriod(userId: string, teamId: string, start: string, end: string) {
     const query = `SELECT COUNT(*) as count FROM muzzle WHERE createdAt >= '${start}' AND createdAt < '${end}' AND teamId='${teamId}' AND requestorId='${userId}';`;
-    return getRepository(Muzzle).query(query);
+    return getRepository(Muzzle)
+      .query(query)
+      .then(res => (res[0].count ? parseInt(res[0].count) : 0));
   }
 }

--- a/src/services/muzzle/muzzle.persistence.service.ts
+++ b/src/services/muzzle/muzzle.persistence.service.ts
@@ -205,7 +205,7 @@ export class MuzzlePersistenceService {
   }
 
   public getMuzzlesByTimePeriod(userId: string, teamId: string, start: string, end: string) {
-    const query = `SELECT COUNT(*) as count FROM muzzle WHERE createdAt >= '${start}' AND createdAt < '${end}' AND teamId='${teamId}' AND slackId='${userId}';`;
+    const query = `SELECT COUNT(*) as count FROM muzzle WHERE createdAt >= '${start}' AND createdAt < '${end}' AND teamId='${teamId}' AND requestorId='${userId}';`;
     return getRepository(Muzzle)
       .query(query)
       .then(item => item.count);

--- a/src/services/muzzle/muzzle.persistence.service.ts
+++ b/src/services/muzzle/muzzle.persistence.service.ts
@@ -1,12 +1,6 @@
 import { UpdateResult, getRepository } from 'typeorm';
 import { Muzzle } from '../../shared/db/models/Muzzle';
-import {
-  ABUSE_PENALTY_TIME,
-  MAX_MUZZLES,
-  MAX_TIME_BETWEEN_MUZZLES,
-  MAX_TOTAL_MUZZLE_COUNT_LENGTH,
-  MuzzleRedisTypeEnum,
-} from './constants';
+import { ABUSE_PENALTY_TIME, MAX_MUZZLES, MAX_TIME_BETWEEN_MUZZLES, MuzzleRedisTypeEnum } from './constants';
 import { RedisPersistenceService } from '../../shared/services/redis.persistence.service';
 import { StorePersistenceService } from '../store/store.persistence.service';
 

--- a/src/services/muzzle/muzzle.persistence.service.ts
+++ b/src/services/muzzle/muzzle.persistence.service.ts
@@ -206,6 +206,8 @@ export class MuzzlePersistenceService {
 
   public getMuzzlesByTimePeriod(userId: string, teamId: string, start: string, end: string) {
     const query = `SELECT COUNT(*) as count FROM muzzle WHERE createdAt >= '${start}' AND createdAt < '${end}' AND teamId='${teamId}' AND slackId='${userId}';`;
-    return getRepository(Muzzle).query(query);
+    return getRepository(Muzzle)
+      .query(query)
+      .then(item => item.count);
   }
 }

--- a/src/services/muzzle/muzzle.persistence.service.ts
+++ b/src/services/muzzle/muzzle.persistence.service.ts
@@ -203,4 +203,9 @@ export class MuzzlePersistenceService {
   private getRedisKeyName(userId: string, teamId: string, userType: MuzzleRedisTypeEnum, withSuppressions = false) {
     return `muzzle.${userType}.${userId}-${teamId}${withSuppressions ? '.suppressions' : ''}`;
   }
+
+  public getMuzzlesByTimePeriod(userId: string, teamId: string, start: string, end: string) {
+    const query = `SELECT COUNT(*) as count FROM muzzle WHERE createdAt >= '${start}' AND createdAt < '${end}' AND teamId='${teamId}' AND slackId='${userId}';`;
+    return getRepository(Muzzle).query(query);
+  }
 }

--- a/src/services/muzzle/muzzle.persistence.service.ts
+++ b/src/services/muzzle/muzzle.persistence.service.ts
@@ -87,23 +87,27 @@ export class MuzzlePersistenceService {
       this.getRedisKeyName(requestorId, teamId, MuzzleRedisTypeEnum.Requestor),
     );
     const requests: number = numberOfRequests ? +numberOfRequests : 0;
-    const newNumber = requests + 1;
+    const outstandingMuzzles = await this.redis.getValue(
+      this.getRedisKeyName(requestorId, teamId, MuzzleRedisTypeEnum.Muzzles),
+    );
+    const newRequests = requests + 1;
+    const newOutstanding = outstandingMuzzles ? +outstandingMuzzles + 1 : 0;
     if (!numberOfRequests) {
       this.redis.setValueWithExpire(
         this.getRedisKeyName(requestorId, teamId, MuzzleRedisTypeEnum.Requestor),
-        newNumber.toString(),
+        newRequests.toString(),
         'EX',
         MAX_TIME_BETWEEN_MUZZLES,
       );
       this.redis.setValueWithExpire(
         this.getRedisKeyName(requestorId, teamId, MuzzleRedisTypeEnum.Muzzles),
-        newNumber.toString(),
+        newOutstanding.toString(),
         'EX',
         MAX_TOTAL_MUZZLE_COUNT_LENGTH,
       );
     } else if (requests < MAX_MUZZLES) {
-      this.redis.setValue(this.getRedisKeyName(requestorId, teamId, MuzzleRedisTypeEnum.Requestor), newNumber);
-      this.redis.setValue(this.getRedisKeyName(requestorId, teamId, MuzzleRedisTypeEnum.Muzzles), newNumber);
+      this.redis.setValue(this.getRedisKeyName(requestorId, teamId, MuzzleRedisTypeEnum.Requestor), newRequests);
+      this.redis.setValue(this.getRedisKeyName(requestorId, teamId, MuzzleRedisTypeEnum.Muzzles), newOutstanding);
     }
   }
 

--- a/src/services/muzzle/muzzle.persistence.service.ts
+++ b/src/services/muzzle/muzzle.persistence.service.ts
@@ -87,11 +87,7 @@ export class MuzzlePersistenceService {
       this.getRedisKeyName(requestorId, teamId, MuzzleRedisTypeEnum.Requestor),
     );
     const requests: number = numberOfRequests ? +numberOfRequests : 0;
-    const outstandingMuzzles = await this.redis.getValue(
-      this.getRedisKeyName(requestorId, teamId, MuzzleRedisTypeEnum.Muzzles),
-    );
     const newRequests = requests + 1;
-    const newOutstanding = outstandingMuzzles ? +outstandingMuzzles + 1 : 0;
     if (!numberOfRequests) {
       this.redis.setValueWithExpire(
         this.getRedisKeyName(requestorId, teamId, MuzzleRedisTypeEnum.Requestor),
@@ -99,20 +95,9 @@ export class MuzzlePersistenceService {
         'EX',
         MAX_TIME_BETWEEN_MUZZLES,
       );
-      this.redis.setValueWithExpire(
-        this.getRedisKeyName(requestorId, teamId, MuzzleRedisTypeEnum.Muzzles),
-        newOutstanding.toString(),
-        'EX',
-        MAX_TOTAL_MUZZLE_COUNT_LENGTH,
-      );
     } else if (requests < MAX_MUZZLES) {
       this.redis.setValue(this.getRedisKeyName(requestorId, teamId, MuzzleRedisTypeEnum.Requestor), newRequests);
-      this.redis.setValue(this.getRedisKeyName(requestorId, teamId, MuzzleRedisTypeEnum.Muzzles), newOutstanding);
     }
-  }
-
-  public async getNumberOfMuzzles(requestorId: string, teamId: string) {
-    return this.redis.getValue(this.getRedisKeyName(requestorId, teamId, MuzzleRedisTypeEnum.Muzzles));
   }
 
   /**

--- a/src/services/muzzle/muzzle.service.spec.ts
+++ b/src/services/muzzle/muzzle.service.spec.ts
@@ -39,8 +39,6 @@ describe('MuzzleService', () => {
           jest
             .spyOn(persistenceService, 'isUserMuzzled')
             .mockImplementation(() => new Promise(resolve => resolve(false)));
-
-          jest.spyOn(muzzleUtils, 'shouldBackfire').mockImplementation(() => false);
         });
 
         it('should call MuzzlePersistenceService.addMuzzle()', async () => {
@@ -58,8 +56,6 @@ describe('MuzzleService', () => {
           const mockMuzzle = { id: 1 };
           const persistenceService = MuzzlePersistenceService.getInstance();
           addMuzzleMock = jest.spyOn(persistenceService, 'addMuzzle').mockResolvedValue(mockMuzzle as Muzzle);
-
-          jest.spyOn(muzzleUtils, 'shouldBackfire').mockImplementation(() => false);
 
           jest.spyOn(persistenceService, 'isUserMuzzled').mockImplementation(
             () =>
@@ -91,9 +87,6 @@ describe('MuzzleService', () => {
           const mockMuzzle = { id: 1 };
           const persistenceService = MuzzlePersistenceService.getInstance();
           addMuzzleMock = jest.spyOn(persistenceService, 'addMuzzle').mockResolvedValue(mockMuzzle as Muzzle);
-
-          jest.spyOn(muzzleUtils, 'shouldBackfire').mockImplementation(() => false);
-
           const mockIsUserMuzzled = jest.spyOn(persistenceService, 'isUserMuzzled');
 
           when(mockIsUserMuzzled)
@@ -115,9 +108,6 @@ describe('MuzzleService', () => {
         const mockMuzzle = { id: 1 };
         const persistenceService = MuzzlePersistenceService.getInstance();
         jest.spyOn(persistenceService, 'addMuzzle').mockResolvedValue(mockMuzzle as Muzzle);
-
-        jest.spyOn(muzzleUtils, 'shouldBackfire').mockImplementation(() => false);
-
         jest
           .spyOn(persistenceService, 'isMaxMuzzlesReached')
           .mockImplementation(() => new Promise(resolve => resolve(true)));

--- a/src/services/muzzle/muzzle.service.ts
+++ b/src/services/muzzle/muzzle.service.ts
@@ -16,9 +16,12 @@ export class MuzzleService extends SuppressorService {
     const requestorName = await this.slackService.getUserNameById(requestorId, teamId);
     const counter = this.counterPersistenceService.getCounterByRequestorId(userId);
     const protectedUser = await this.storePersistenceService.isProtected(userId, teamId);
+    const isMuzzleBot = this.isMuzzleBot(userId);
 
     return new Promise(async (resolve, reject) => {
-      if (!userId) {
+      if (isMuzzleBot) {
+        reject('Sorry, you cannot muzzle the muzzle.');
+      } else if (!userId) {
         reject(`Invalid username passed in. You can only muzzle existing slack users.`);
       } else if (await this.isSuppressed(userId, teamId)) {
         console.error(

--- a/src/services/muzzle/muzzle.service.ts
+++ b/src/services/muzzle/muzzle.service.ts
@@ -16,11 +16,15 @@ export class MuzzleService extends SuppressorService {
     const requestorName = await this.slackService.getUserNameById(requestorId, teamId);
     const counter = this.counterPersistenceService.getCounterByRequestorId(userId);
     const protectedUser = await this.storePersistenceService.isProtected(userId, teamId);
-    const isMuzzleBot = this.isMuzzleBot(userId);
+    const isBot = await this.isBot(userId, teamId);
 
+    console.log('userId', userId);
+    console.log('requestorId', requestorId);
+    console.log('teamId', teamId);
+    console.log('channel');
     return new Promise(async (resolve, reject) => {
-      if (isMuzzleBot) {
-        reject('Sorry, you cannot muzzle the muzzle.');
+      if (isBot) {
+        reject('Sorry, you cannot muzzle bots.');
       } else if (!userId) {
         reject(`Invalid username passed in. You can only muzzle existing slack users.`);
       } else if (await this.isSuppressed(userId, teamId)) {

--- a/src/services/muzzle/muzzle.service.ts
+++ b/src/services/muzzle/muzzle.service.ts
@@ -1,5 +1,5 @@
 import { MAX_MUZZLES, MAX_SUPPRESSIONS } from './constants';
-import { getTimeString, getTimeToMuzzle, shouldBackfire } from './muzzle-utilities';
+import { getTimeString, getTimeToMuzzle } from './muzzle-utilities';
 import { SuppressorService } from '../../shared/services/suppressor.service';
 import { CounterService } from '../counter/counter.service';
 import { StorePersistenceService } from '../store/store.persistence.service';

--- a/src/services/muzzle/muzzle.service.ts
+++ b/src/services/muzzle/muzzle.service.ts
@@ -18,10 +18,6 @@ export class MuzzleService extends SuppressorService {
     const protectedUser = await this.storePersistenceService.isProtected(userId, teamId);
     const isBot = await this.isBot(userId, teamId);
 
-    console.log('userId', userId);
-    console.log('requestorId', requestorId);
-    console.log('teamId', teamId);
-    console.log('channel');
     return new Promise(async (resolve, reject) => {
       if (isBot) {
         reject('Sorry, you cannot muzzle bots.');

--- a/src/services/muzzle/muzzle.service.ts
+++ b/src/services/muzzle/muzzle.service.ts
@@ -11,7 +11,7 @@ export class MuzzleService extends SuppressorService {
    * Adds a user to the muzzled map and sets a timeout to remove the muzzle within a random time of 30 seconds to 3 minutes
    */
   public async addUserToMuzzled(userId: string, requestorId: string, teamId: string, channel: string): Promise<string> {
-    const shouldBackFire = shouldBackfire();
+    const shouldBackFire = await this.shouldBackfire(requestorId, teamId);
     const userName = await this.slackService.getUserNameById(userId, teamId);
     const requestorName = await this.slackService.getUserNameById(requestorId, teamId);
     const counter = this.counterPersistenceService.getCounterByRequestorId(userId);

--- a/src/services/slack/slack.persistence.service.ts
+++ b/src/services/slack/slack.persistence.service.ts
@@ -49,7 +49,8 @@ export class SlackPersistenceService {
         slackId: user.id,
         name: user.profile.display_name || user.name,
         teamId: user.team_id,
-        isBot: user.is_bot ? user.is_bot : false,
+        botId: user?.profile?.bot_id,
+        isBot: !!user.is_bot,
       };
     });
     try {
@@ -69,6 +70,10 @@ export class SlackPersistenceService {
 
   async getUserById(userId: string, teamId: string): Promise<SlackUser | undefined> {
     return getRepository(SlackUser).findOne({ slackId: userId, teamId });
+  }
+
+  async getBotByBotId(botId: string, teamId: string): Promise<SlackUser | undefined> {
+    return getRepository(SlackUser).findOne({ botId, teamId });
   }
 
   async getChannelById(channelId: string, teamId: string): Promise<SlackChannel | undefined> {

--- a/src/services/slack/slack.persistence.service.ts
+++ b/src/services/slack/slack.persistence.service.ts
@@ -43,6 +43,7 @@ export class SlackPersistenceService {
 
   // This sucks because TypeORM sucks. Time to consider removing this ORM.
   async saveUsers(users: SlackUserModel[]): Promise<void> {
+    console.log(users);
     const dbUsers = users.map(user => {
       return {
         slackId: user.id,

--- a/src/services/slack/slack.persistence.service.ts
+++ b/src/services/slack/slack.persistence.service.ts
@@ -49,7 +49,7 @@ export class SlackPersistenceService {
         slackId: user.id,
         name: user.profile.display_name || user.name,
         teamId: user.team_id,
-        botId: user?.profile?.bot_id,
+        botId: user?.profile?.bot_id ? user.profile.bot_id : '',
         isBot: !!user.is_bot,
       };
     });

--- a/src/services/slack/slack.persistence.service.ts
+++ b/src/services/slack/slack.persistence.service.ts
@@ -48,6 +48,7 @@ export class SlackPersistenceService {
         slackId: user.id,
         name: user.profile.display_name || user.name,
         teamId: user.team_id,
+        isBot: user.is_bot ? user.is_bot : false,
       };
     });
     try {

--- a/src/services/slack/slack.persistence.service.ts
+++ b/src/services/slack/slack.persistence.service.ts
@@ -43,7 +43,6 @@ export class SlackPersistenceService {
 
   // This sucks because TypeORM sucks. Time to consider removing this ORM.
   async saveUsers(users: SlackUserModel[]): Promise<void> {
-    console.log(users);
     const dbUsers = users.map(user => {
       return {
         slackId: user.id,

--- a/src/services/slack/slack.service.ts
+++ b/src/services/slack/slack.service.ts
@@ -85,19 +85,21 @@ export class SlackService {
   /**
    * Retrieves a list of all users.
    */
-  public getAllUsers(): void {
+  public getAllUsers(): Promise<SlackUser[]> {
     console.log('Retrieving new user list...');
-    this.web
+    return this.web
       .getAllUsers()
       .then(resp => {
         console.log('New user list has been retrieved!');
         this.persistenceService.saveUsers(resp.members as SlackUser[]);
+        return resp.members as SlackUser[];
       })
       .catch(e => {
         console.error('Failed to retrieve users', e);
         console.timeEnd('retrieved user list in: ');
         console.error('Retrying in 5 seconds...');
         setTimeout(() => this.getAllUsers(), 5000);
+        throw new Error('Unable to retrieve users');
       });
   }
 }

--- a/src/services/slack/slack.service.ts
+++ b/src/services/slack/slack.service.ts
@@ -86,13 +86,15 @@ export class SlackService {
   /**
    * Retrieves a list of all users.
    */
-  public getAllUsers(): Promise<SlackUser[]> {
+  public getAllUsers(shouldSave?: boolean): Promise<SlackUser[]> {
     console.log('Retrieving new user list...');
     return this.web
       .getAllUsers()
       .then(resp => {
         console.log('New user list has been retrieved!');
-        this.persistenceService.saveUsers(resp.members as SlackUser[]);
+        if (shouldSave) {
+          this.persistenceService.saveUsers(resp.members as SlackUser[]);
+        }
         return resp.members as SlackUser[];
       })
       .catch(e => {

--- a/src/services/slack/slack.service.ts
+++ b/src/services/slack/slack.service.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { ChannelResponse, SlackUser } from '../../shared/models/slack/slack-models';
+import { SlackUser as SlackUserFromDB } from '../../shared/db/models/SlackUser';
 import { WebService } from '../web/web.service';
 import { USER_ID_REGEX } from './constants';
 import { SlackPersistenceService } from './slack.persistence.service';
@@ -101,5 +102,9 @@ export class SlackService {
         setTimeout(() => this.getAllUsers(), 5000);
         throw new Error('Unable to retrieve users');
       });
+  }
+
+  public getUserById(userId: string, teamId: string): Promise<SlackUserFromDB | undefined> {
+    return this.persistenceService.getUserById(userId, teamId);
   }
 }

--- a/src/services/slack/slack.service.ts
+++ b/src/services/slack/slack.service.ts
@@ -104,7 +104,7 @@ export class SlackService {
       });
   }
 
-  public getUserById(userId: string, teamId: string): Promise<SlackUserFromDB | undefined> {
-    return this.persistenceService.getUserById(userId, teamId);
+  public getBotByBotId(botId: string, teamId: string): Promise<SlackUserFromDB | undefined> {
+    return this.persistenceService.getBotByBotId(botId, teamId);
   }
 }

--- a/src/services/slack/slack.service.ts
+++ b/src/services/slack/slack.service.ts
@@ -107,4 +107,8 @@ export class SlackService {
   public getBotByBotId(botId: string, teamId: string): Promise<SlackUserFromDB | undefined> {
     return this.persistenceService.getBotByBotId(botId, teamId);
   }
+
+  public getUserById(userId: string, teamId: string): Promise<SlackUserFromDB | undefined> {
+    return this.persistenceService.getUserById(userId, teamId);
+  }
 }

--- a/src/shared/db/models/SlackUser.ts
+++ b/src/shared/db/models/SlackUser.ts
@@ -20,6 +20,9 @@ export class SlackUser {
   @Column()
   public isBot!: boolean;
 
+  @Column()
+  public botId!: string;
+
   @OneToMany(
     _type => InventoryItem,
     inventoryItem => inventoryItem.owner,

--- a/src/shared/db/models/SlackUser.ts
+++ b/src/shared/db/models/SlackUser.ts
@@ -17,6 +17,9 @@ export class SlackUser {
   @Column()
   public teamId!: string;
 
+  @Column()
+  public isBot!: boolean;
+
   @OneToMany(
     _type => InventoryItem,
     inventoryItem => inventoryItem.owner,

--- a/src/shared/models/slack/slack-models.ts
+++ b/src/shared/models/slack/slack-models.ts
@@ -71,7 +71,6 @@ export interface SlackUser {
   tz: string;
   tz_label: string;
   tz_offset: number;
-  profile: any;
   is_admin: boolean;
   is_owner: boolean;
   is_primary_owner: boolean;
@@ -80,4 +79,8 @@ export interface SlackUser {
   is_bot: boolean;
   is_app_user: boolean;
   updated: number;
+  profile: {
+    bot_id: string;
+    display_name: string;
+  };
 }

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -192,7 +192,7 @@ export class SuppressorService {
       .getNumberOfMuzzles(requestorId, teamId)
       .then(val => (val ? parseInt(val) : 0));
     console.log(`Number of muzzles for ${requestorId}: ${muzzles}`);
-    const chanceOfBackfire = 0.05 + muzzles * 0.01;
+    const chanceOfBackfire = 0.05 + muzzles * 0.05;
     console.log(`Chance of Backfire for ${requestorId}: ${chanceOfBackfire}`);
     return Math.random() <= chanceOfBackfire;
   }

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -192,6 +192,7 @@ export class SuppressorService {
       .getNumberOfMuzzles(requestorId, teamId)
       .then(val => (val ? parseInt(val) : 0));
     const chanceOfBackfire = 0.05 + muzzles * 0.01;
+    console.log(`Chance of Backfire for ${requestorId}: ${chanceOfBackfire}`);
     return Math.random() <= chanceOfBackfire;
   }
 }

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -38,7 +38,7 @@ export class SuppressorService {
   }
 
   // Built for spoiler only. This will not work on other block apps. Should improve this to be universal.
-  public async findUserInBlocks(blocks: any, users?: SlackUser[]): string | undefined {
+  public async findUserInBlocks(blocks: any, users?: SlackUser[]): Promise<string | undefined> {
     const allUsers: SlackUser[] = users ? users : await this.slackService.getAllUsers();
 
     let id;

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -92,11 +92,11 @@ export class SuppressorService {
    * Determines whether or not a bot message should be removed.
    */
   public async shouldBotMessageBeMuzzled(request: EventRequest): Promise<boolean> {
-    if (
-      (request.event.bot_id || request.event.subtype === 'bot_message') &&
-      ((request.event.username && request.event.username.toLowerCase() !== 'muzzle') ||
-        (request.event.bot_profile && request.event.bot_profile.name.toLowerCase() !== 'muzzle'))
-    ) {
+    const isBot = await this.slackService
+      .getUserById(request.event.bot_id, request.team_id)
+      .then(user => user?.name !== 'muzzle' && user?.isBot);
+
+    if (isBot) {
       let userIdByEventText;
       let userIdByAttachmentText;
       let userIdByAttachmentPretext;

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -235,6 +235,7 @@ export class SuppressorService {
       .format('YYYY-MM-DD HH:mm:ss');
     const end = moment().format('YYYY-MM-DD HH:mm:ss');
     const muzzles = await this.muzzlePersistenceService.getMuzzlesByTimePeriod(requestorId, teamId, start, end);
+    console.log(muzzles);
     Object.keys(muzzles).forEach(key => console.log(key));
     console.log(`Number of muzzles for ${requestorId}: ${muzzles}`);
     const chanceOfBackfire = 0.05 + muzzles * 0.025;

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -17,6 +17,10 @@ export class SuppressorService {
   public counterPersistenceService = CounterPersistenceService.getInstance();
   public translationService = new TranslationService();
 
+  public isMuzzleBot(userId: string) {
+    return userId === 'ULG8SJRFF';
+  }
+
   public findUserIdInBlocks(obj: any, regEx: RegExp): string | undefined {
     let id;
     Object.keys(obj).forEach(key => {

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -43,19 +43,21 @@ export class SuppressorService {
     console.log(blocks);
     let id;
     const firstBlock = blocks[0]?.elements?.[0];
-    Object.keys(firstBlock).forEach(key => {
-      if (typeof firstBlock[key] === 'string') {
-        allUsers.forEach(user => {
-          console.log(user);
-          if (firstBlock[key].includes(user.name)) {
-            id = user.id;
-          }
-        });
-      }
-      if (typeof firstBlock[key] === 'object') {
-        id = this.findUserInBlocks(firstBlock[key], allUsers);
-      }
-    });
+    if (firstBlock) {
+      Object.keys(firstBlock).forEach(key => {
+        if (typeof firstBlock[key] === 'string') {
+          allUsers.forEach(user => {
+            console.log(user);
+            if (firstBlock[key].includes(user.name)) {
+              id = user.id;
+            }
+          });
+        }
+        if (typeof firstBlock[key] === 'object') {
+          id = this.findUserInBlocks(firstBlock[key], allUsers);
+        }
+      });
+    }
     return id;
   }
 

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -235,6 +235,7 @@ export class SuppressorService {
       .format('YYYY-MM-DD HH:mm:ss');
     const end = moment().format('YYYY-MM-DD HH:mm:ss');
     const muzzles = await this.muzzlePersistenceService.getMuzzlesByTimePeriod(requestorId, teamId, start, end);
+    Object.keys(muzzles).forEach(key => console.log(key));
     console.log(`Number of muzzles for ${requestorId}: ${muzzles}`);
     const chanceOfBackfire = 0.05 + muzzles * 0.025;
     console.log(`Chance of Backfire for ${requestorId}: ${chanceOfBackfire}`);

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -234,11 +234,7 @@ export class SuppressorService {
       .subtract(7, 'days')
       .format('YYYY-MM-DD HH:mm:ss');
     const end = moment().format('YYYY-MM-DD HH:mm:ss');
-    const muzzles = await this.muzzlePersistenceService
-      .getMuzzlesByTimePeriod(requestorId, teamId, start, end)
-      .then(res => res[0].count);
-    console.log(muzzles);
-    Object.keys(muzzles).forEach(key => console.log(key));
+    const muzzles = await this.muzzlePersistenceService.getMuzzlesByTimePeriod(requestorId, teamId, start, end);
     console.log(`Number of muzzles for ${requestorId}: ${muzzles}`);
     const chanceOfBackfire = 0.05 + muzzles * 0.025;
     console.log(`Chance of Backfire for ${requestorId}: ${chanceOfBackfire}`);

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -92,9 +92,11 @@ export class SuppressorService {
    * Determines whether or not a bot message should be removed.
    */
   public async shouldBotMessageBeMuzzled(request: EventRequest): Promise<boolean> {
-    const isBot = await this.slackService
-      .getUserById(request.event.bot_id, request.team_id)
-      .then(user => user?.name !== 'muzzle' && user?.isBot);
+    const isBot = request.event.bot_id
+      ? await this.slackService
+          .getBotByBotId(request.event.bot_id, request.team_id)
+          .then(user => user?.name !== 'muzzle')
+      : false;
 
     if (isBot) {
       let userIdByEventText;

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -40,9 +40,9 @@ export class SuppressorService {
   // Built for spoiler only. This will not work on other block apps. Should improve this to be universal.
   public async findUserInBlocks(blocks: any, users?: SlackUser[]): Promise<string | undefined> {
     const allUsers: SlackUser[] = users ? users : await this.slackService.getAllUsers();
-
+    console.log(blocks);
     let id;
-    const firstBlock = blocks[0]?.elements[0];
+    const firstBlock = blocks[0]?.elements?.[0];
     Object.keys(firstBlock).forEach(key => {
       if (typeof firstBlock[key] === 'string') {
         allUsers.forEach(user => {
@@ -102,7 +102,11 @@ export class SuppressorService {
       let userIdByCallbackId;
       let userIdByBlocks;
 
+      console.log('Bot message found');
+
       if (request.event.blocks) {
+        console.log('Has blocks');
+        console.log(request.event.blocks);
         const userId = this.findUserIdInBlocks(request.event.blocks, USER_ID_REGEX);
         const userName = await this.findUserInBlocks(request.event.blocks);
         console.log('ID found for spoiler muzzle:' + userName);

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -17,8 +17,8 @@ export class SuppressorService {
   public counterPersistenceService = CounterPersistenceService.getInstance();
   public translationService = new TranslationService();
 
-  public isMuzzleBot(userId: string) {
-    return userId === 'ULG8SJRFF';
+  public isBot(userId: string, teamId: string): Promise<boolean | undefined> {
+    return this.slackService.getUserById(userId, teamId).then(user => !!user?.isBot);
   }
 
   public findUserIdInBlocks(obj: any, regEx: RegExp): string | undefined {

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -191,6 +191,7 @@ export class SuppressorService {
     const muzzles = await this.muzzlePersistenceService
       .getNumberOfMuzzles(requestorId, teamId)
       .then(val => (val ? parseInt(val) : 0));
+    console.log(`Number of muzzles for ${requestorId}: ${muzzles}`);
     const chanceOfBackfire = 0.05 + muzzles * 0.01;
     console.log(`Chance of Backfire for ${requestorId}: ${chanceOfBackfire}`);
     return Math.random() <= chanceOfBackfire;

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -46,6 +46,7 @@ export class SuppressorService {
     Object.keys(firstBlock).forEach(key => {
       if (typeof firstBlock[key] === 'string') {
         allUsers.forEach(user => {
+          console.log(user);
           if (firstBlock[key].includes(user.name)) {
             id = user.id;
           }

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -186,4 +186,12 @@ export class SuppressorService {
 
     return returnText;
   }
+
+  public async shouldBackfire(requestorId: string, teamId: string): Promise<boolean> {
+    const muzzles = await this.muzzlePersistenceService
+      .getNumberOfMuzzles(requestorId, teamId)
+      .then(val => (val ? parseInt(val) : 0));
+    const chanceOfBackfire = 0.05 + muzzles * 0.01;
+    return Math.random() <= chanceOfBackfire;
+  }
 }

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -8,6 +8,7 @@ import { WebService } from '../../services/web/web.service';
 import { isRandomEven } from '../../services/muzzle/muzzle-utilities';
 import { MAX_WORD_LENGTH, REPLACEMENT_TEXT } from '../../services/muzzle/constants';
 import { TranslationService } from './translation.service';
+import moment from 'moment';
 
 export class SuppressorService {
   public webService = WebService.getInstance();
@@ -228,11 +229,14 @@ export class SuppressorService {
   }
 
   public async shouldBackfire(requestorId: string, teamId: string): Promise<boolean> {
-    const muzzles = await this.muzzlePersistenceService
-      .getNumberOfMuzzles(requestorId, teamId)
-      .then(val => (val ? parseInt(val) : 0));
+    const start = moment()
+      .startOf('day')
+      .subtract(7, 'days')
+      .format('YYYY-MM-DD HH:mm:ss');
+    const end = moment().format('YYYY-MM-DD HH:mm:ss');
+    const muzzles = await this.muzzlePersistenceService.getMuzzlesByTimePeriod(requestorId, teamId, start, end);
     console.log(`Number of muzzles for ${requestorId}: ${muzzles}`);
-    const chanceOfBackfire = 0.05 + muzzles * 0.05;
+    const chanceOfBackfire = 0.05 + muzzles * 0.025;
     console.log(`Chance of Backfire for ${requestorId}: ${chanceOfBackfire}`);
     return Math.random() <= chanceOfBackfire;
   }

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -234,7 +234,9 @@ export class SuppressorService {
       .subtract(7, 'days')
       .format('YYYY-MM-DD HH:mm:ss');
     const end = moment().format('YYYY-MM-DD HH:mm:ss');
-    const muzzles = await this.muzzlePersistenceService.getMuzzlesByTimePeriod(requestorId, teamId, start, end);
+    const muzzles = await this.muzzlePersistenceService
+      .getMuzzlesByTimePeriod(requestorId, teamId, start, end)
+      .then(res => res[0].count);
     console.log(muzzles);
     Object.keys(muzzles).forEach(key => console.log(key));
     console.log(`Number of muzzles for ${requestorId}: ${muzzles}`);


### PR DESCRIPTION
- Added increase backfire percentage baed on how many muzzles you have sent
- Removed bad import
- Added log for chance of backfire
- added additional log for number of muzzles
- Changed MAX_TOTAL_MUZZLE_COUNT_LENGTH to 7 days
- Fixed the outstanding muzzles bug
- Changed backfire percent to be 5% more per muzzle
- Added hotfix to prevent muzzle from attempting to muzzle itself
- Added logging to event controller to debug spoiler issue
- Added blocks log
- Added handler for spoiler
- Added proper return type
- Added ?
- Commented out log
- Logging and stuff
- Addded log for users
- Added isBot to the schema for slackUser
- Added better way to identify bot messages
- Added log for users
- Added support for better bot id handlling
- Added null handling for botId
- Added null check
- Removed ability to muzzle bots
- Lowered chance from 5% to 2.5% for each muzzle a user has. Also change to source trailing7 muzzles rather than use redis
- Changed getMuzzlesByTimePeriod to return count
- fixed query
- Remove item.count
- added log to debug
- Added more logs
- Fixed issues
- Moved number access to muzzle persistance service
- Adjusted getAllUsers
