### PR TITLE
feature/automated muzzles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/jest-when": "^2.7.0",
         "@types/lolex": "^3.1.1",
         "@types/node": "^12.12.56",
+        "@types/sentiment": "^5.0.1",
         "@typescript-eslint/eslint-plugin": "^2.30.0",
         "@typescript-eslint/parser": "^2.30.0",
         "axios": "^0.18.1",
@@ -26,6 +27,7 @@
         "ioredis": "^4.17.3",
         "moment": "^2.24.0",
         "mysql": "^2.17.1",
+        "sentiment": "^5.0.2",
         "typeorm": "^0.2.25",
         "typescript": "^3.9.7"
       },
@@ -2493,6 +2495,11 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+    },
+    "node_modules/@types/sentiment": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sentiment/-/sentiment-5.0.1.tgz",
+      "integrity": "sha512-EDqF8DFWaVVlEUZ35y+4B3dxI7JCKj0l35umQzi1NksqEihFexvGiMTE7Jd/R7Ottc0eicfgjskWkuBcDQRuuQ=="
     },
     "node_modules/@types/serve-static": {
       "version": "1.13.5",
@@ -12891,6 +12898,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
+    "node_modules/sentiment": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sentiment/-/sentiment-5.0.2.tgz",
+      "integrity": "sha512-ZeC3y0JsOYTdwujt5uOd7ILJNilbgFzUtg/LEG4wUv43LayFNLZ28ec8+Su+h3saHlJmIwYxBzfDHHZuiMA15g==",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/serve-static": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
@@ -17104,6 +17119,11 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+    },
+    "@types/sentiment": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sentiment/-/sentiment-5.0.1.tgz",
+      "integrity": "sha512-EDqF8DFWaVVlEUZ35y+4B3dxI7JCKj0l35umQzi1NksqEihFexvGiMTE7Jd/R7Ottc0eicfgjskWkuBcDQRuuQ=="
     },
     "@types/serve-static": {
       "version": "1.13.5",
@@ -25441,6 +25461,11 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
+    },
+    "sentiment": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sentiment/-/sentiment-5.0.2.tgz",
+      "integrity": "sha512-ZeC3y0JsOYTdwujt5uOd7ILJNilbgFzUtg/LEG4wUv43LayFNLZ28ec8+Su+h3saHlJmIwYxBzfDHHZuiMA15g=="
     },
     "serve-static": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/jest-when": "^2.7.0",
     "@types/lolex": "^3.1.1",
     "@types/node": "^12.12.56",
+    "@types/sentiment": "^5.0.1",
     "@typescript-eslint/eslint-plugin": "^2.30.0",
     "@typescript-eslint/parser": "^2.30.0",
     "axios": "^0.18.1",
@@ -36,6 +37,7 @@
     "ioredis": "^4.17.3",
     "moment": "^2.24.0",
     "mysql": "^2.17.1",
+    "sentiment": "^5.0.2",
     "typeorm": "^0.2.25",
     "typescript": "^3.9.7"
   },

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -202,7 +202,7 @@ eventController.post('/muzzle/handle', async (req: Request, res: Response) => {
       handleReaction(request);
     } else if (isInHotAndNotBot) {
       deleteMessage(request);
-    } else {
+    } else if (!isReaction && !isNewChannelCreated && !isNewUserAdded) {
       handleAutoMuzzle(request);
     }
     handleActivity(request);

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -164,7 +164,7 @@ function handleActivity(request: EventRequest): void {
   activityPersistenceService.updateLatestHotness();
 }
 
-function handleAutoMuzzle(request: EventRequest): void {
+function logSentiment(request: EventRequest): void {
   sentimentService.performSentimentAnalysis(
     request.event.user,
     request.team_id,
@@ -208,7 +208,7 @@ eventController.post('/muzzle/handle', async (req: Request, res: Response) => {
     } else if (isInHotAndNotBot) {
       deleteMessage(request);
     } else if (!isReaction && !isNewChannelCreated && !isNewUserAdded) {
-      handleAutoMuzzle(request);
+      logSentiment(request);
     }
     handleActivity(request);
     console.timeEnd('respond-to-event');

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -165,7 +165,12 @@ function handleActivity(request: EventRequest): void {
 }
 
 function handleAutoMuzzle(request: EventRequest): void {
-  sentimentService.performSentimentAnalysis(request.event.user, request.team_id, request.event.text);
+  sentimentService.performSentimentAnalysis(
+    request.event.user,
+    request.team_id,
+    request.event.channel,
+    request.event.text,
+  );
 }
 
 // Change route to /event/handle instead.

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -9,6 +9,7 @@ import { getTimeString } from '../services/muzzle/muzzle-utilities';
 import { MuzzlePersistenceService } from '../services/muzzle/muzzle.persistence.service';
 import { MuzzleService } from '../services/muzzle/muzzle.service';
 import { ReactionService } from '../services/reaction/reaction.service';
+import { SentimentService } from '../services/sentiment/sentiment.service';
 import { SlackService } from '../services/slack/slack.service';
 import { WebService } from '../services/web/web.service';
 import { CounterMuzzle } from '../shared/models/counter/counter-models';
@@ -24,6 +25,7 @@ const reactionService = new ReactionService();
 const webService = WebService.getInstance();
 const slackService = SlackService.getInstance();
 const suppressorService = new SuppressorService();
+const sentimentService = new SentimentService();
 const muzzlePersistenceService = MuzzlePersistenceService.getInstance();
 const backfirePersistenceService = BackFirePersistenceService.getInstance();
 const counterPersistenceService = CounterPersistenceService.getInstance();
@@ -161,6 +163,11 @@ function handleActivity(request: EventRequest): void {
   activityPersistenceService.logActivity(request);
   activityPersistenceService.updateLatestHotness();
 }
+
+function handleAutoMuzzle(request: EventRequest): void {
+  sentimentService.performSentimentAnalysis(request.event.user, request.team_id, request.event.text);
+}
+
 // Change route to /event/handle instead.
 eventController.post('/muzzle/handle', async (req: Request, res: Response) => {
   if (req.body.challenge) {
@@ -175,7 +182,6 @@ eventController.post('/muzzle/handle', async (req: Request, res: Response) => {
     const isReaction = request.event.type === 'reaction_added' || request.event.type === 'reaction_removed';
     const isMuzzled = await muzzlePersistenceService.isUserMuzzled(request.event.user, request.team_id);
     const isUserBackfired = await backfirePersistenceService.isBackfire(request.event.user, request.team_id);
-    // TO DO: Add teamId to this call once counterPersistenceService uses redis.
     const isUserCounterMuzzled = await counterPersistenceService.isCounterMuzzled(request.event.user);
     const isMuzzleBot = request.event.user === 'ULG8SJRFF';
     const isInHotAndNotBot = !isMuzzleBot && request.event.channel === 'C027YMYC5CJ';
@@ -196,6 +202,8 @@ eventController.post('/muzzle/handle', async (req: Request, res: Response) => {
       handleReaction(request);
     } else if (isInHotAndNotBot) {
       deleteMessage(request);
+    } else {
+      handleAutoMuzzle(request);
     }
     handleActivity(request);
     console.timeEnd('respond-to-event');

--- a/src/services/list/ListUser.model.ts
+++ b/src/services/list/ListUser.model.ts
@@ -1,0 +1,4 @@
+export interface ListUser {
+  text: string;
+  name: string;
+}

--- a/src/services/list/list.report.service.ts
+++ b/src/services/list/list.report.service.ts
@@ -1,15 +1,13 @@
 import Table from 'easy-table';
 import { ReportService } from '../../shared/services/report.service';
-import { List } from '../../shared/db/models/List';
-import { getManager, getRepository } from 'typeorm';
+import { getManager } from 'typeorm';
 import { ListUser } from './ListUser.model';
 
 export class ListReportService extends ReportService {
   // TODO: Add Team ID to the query.
   public async getListReport(): Promise<string> {
     const query = `SELECT u.name, l.text FROM list AS l INNER JOIN slack_user AS u ON u.slackId=l.requestorId;    `;
-    await getManager().query(query);
-    const listReport = await getRepository(List).find();
+    const listReport = await getManager().query(query);
     return this.formatListReport(listReport);
   }
 

--- a/src/services/list/list.report.service.ts
+++ b/src/services/list/list.report.service.ts
@@ -1,18 +1,21 @@
 import Table from 'easy-table';
 import { ReportService } from '../../shared/services/report.service';
 import { List } from '../../shared/db/models/List';
-import { getRepository } from 'typeorm';
+import { getManager, getRepository } from 'typeorm';
+import { ListUser } from './ListUser.model';
 
 export class ListReportService extends ReportService {
   // TODO: Add Team ID to the query.
   public async getListReport(): Promise<string> {
+    const query = `SELECT u.name, l.text FROM list AS l INNER JOIN slack_user AS u ON u.slackId=l.requestorId;    `;
+    await getManager().query(query);
     const listReport = await getRepository(List).find();
     return this.formatListReport(listReport);
   }
 
   private formatListReport(report: any): string {
-    const reportWithoutDate = report.map((listItem: List) => {
-      return { Item: listItem.text };
+    const reportWithoutDate = report.map((listItem: ListUser) => {
+      return { Item: `${listItem.text} - ${listItem.name}` };
     });
 
     return `

--- a/src/services/muzzle/muzzle.service.ts
+++ b/src/services/muzzle/muzzle.service.ts
@@ -98,7 +98,10 @@ export class MuzzleService extends SuppressorService {
     timestamp: string,
   ): Promise<void> {
     console.time('send-muzzled-message');
-    const muzzle: string | null = await this.muzzlePersistenceService.getMuzzle(userId, teamId);
+    const muzzle: string | null = await this.muzzlePersistenceService.getMuzzle(userId, teamId).catch(e => {
+      console.error('error retrieving muzzle', e);
+      return null;
+    });
     if (muzzle) {
       const suppressions = await this.muzzlePersistenceService.getSuppressions(userId, teamId);
       if (!suppressions || (suppressions && +suppressions < MAX_SUPPRESSIONS)) {

--- a/src/services/muzzle/muzzle.service.ts
+++ b/src/services/muzzle/muzzle.service.ts
@@ -7,9 +7,7 @@ import { StorePersistenceService } from '../store/store.persistence.service';
 export class MuzzleService extends SuppressorService {
   private counterService = new CounterService();
   private storePersistenceService = StorePersistenceService.getInstance();
-  /**
-   * Adds a user to the muzzled map and sets a timeout to remove the muzzle within a random time of 30 seconds to 3 minutes
-   */
+
   public async addUserToMuzzled(userId: string, requestorId: string, teamId: string, channel: string): Promise<string> {
     const shouldBackFire = await this.shouldBackfire(requestorId, teamId);
     const userName = await this.slackService.getUserNameById(userId, teamId);

--- a/src/services/muzzle/muzzle.service.ts
+++ b/src/services/muzzle/muzzle.service.ts
@@ -8,31 +8,6 @@ export class MuzzleService extends SuppressorService {
   private counterService = new CounterService();
   private storePersistenceService = StorePersistenceService.getInstance();
 
-  public async autoMuzzle(userId: string, teamId: string): Promise<string> {
-    if (!userId) {
-      throw new Error(`Invalid username passed in. You can only muzzle existing slack users.`);
-    }
-    const userName = await this.slackService.getUserNameById(userId, teamId);
-    const requestorId = (await this.slackService.getUserIdByName('muzzle', teamId)) as string;
-    if (await this.isSuppressed(userId, teamId)) {
-      console.error(
-        `Automuzzle attempted to muzzle ${userName} | ${userId} but ${userName} | ${userId} is already muzzled.`,
-      );
-      throw new Error(`${userName} is already muzzled!`);
-    } else {
-      const timeToMuzzle = getTimeToMuzzle();
-      return await this.muzzlePersistenceService
-        .addMuzzle(requestorId, userId, teamId, timeToMuzzle)
-        .then(() => {
-          return `Successfully auto-muzzled ${userName} for ${getTimeString(timeToMuzzle)}`;
-        })
-        .catch((e: any) => {
-          console.error(e);
-          throw new Error(`Muzzle failed!`);
-        });
-    }
-  }
-
   public async addUserToMuzzled(userId: string, requestorId: string, teamId: string, channel: string): Promise<string> {
     const shouldBackFire = await this.shouldBackfire(requestorId, teamId);
     const userName = await this.slackService.getUserNameById(userId, teamId);

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -1,16 +1,9 @@
-import moment from 'moment';
 import Sentiment, { AnalysisOptions, AnalysisResult } from 'sentiment';
 import { getRepository, InsertResult } from 'typeorm';
 import { Sentiment as SentimentDB } from '../../shared/db/models/Sentiment';
-import { MuzzleService } from '../muzzle/muzzle.service';
-import { SlackService } from '../slack/slack.service';
-import { WebService } from '../web/web.service';
 
 export class SentimentService {
   sentiment = new Sentiment();
-  private webService = WebService.getInstance();
-  private slackService = SlackService.getInstance();
-  private muzzleService = new MuzzleService();
 
   public performSentimentAnalysis(userId: string, teamId: string, channelId: string, text: string): void {
     this.analyzeSentimentAndStore(userId, teamId, channelId, text);
@@ -49,36 +42,5 @@ export class SentimentService {
     return getRepository(SentimentDB)
       .query(query)
       .then(result => result);
-  }
-
-  // Unused - keeping in case we want to bring this back.
-  public async autoMuzzleIfNecessary(userId: string, teamId: string): Promise<void> {
-    const start = moment()
-      .subtract(5, 'minutes')
-      .format('YYYY-MM-DD HH:mm:ss');
-    const end = moment().format('YYYY-MM-DD HH:mm:ss');
-    const averageSentiment = await this.getAvgSentimentForTimePeriod(userId, teamId, start, end);
-    const avgAndStd = await this.getAvgAndSTD(teamId);
-    const avgMinusOneStd = avgAndStd?.[0]?.avg - avgAndStd?.[0]?.std;
-    console.log(averageSentiment);
-    console.log('user avg', averageSentiment?.[0]?.avg);
-    console.log('team std', avgAndStd?.[0]?.std);
-    console.log('team avg', avgAndStd?.[0]?.avg);
-    console.log('team avg minus std', avgMinusOneStd);
-    if (averageSentiment?.[0]?.avg <= avgMinusOneStd && averageSentiment?.[0]?.count >= 5) {
-      console.log(`${userId} should be muzzled.`);
-      this.slackService.getUserById(userId, teamId).then(user => {
-        this.webService.sendDebugMessage(
-          'U2YJQN2KB',
-          `${user?.name} should be muzzled. 
-          User Average was ${averageSentiment?.[0]?.avg}.
-          Team Average was ${avgAndStd?.[0]?.avg}.
-          Team STD was ${avgAndStd?.[0]?.std}.
-          Team Average Minus STD was ${avgMinusOneStd}.
-          `,
-        );
-        this.muzzleService.autoMuzzle(userId, teamId);
-      });
-    }
   }
 }

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -29,7 +29,7 @@ export class SentimentService {
   }
 
   getAvgAndSTD(teamId: string): Promise<any> {
-    const query = `SELECT AVG(sentiment) as avg, STD(sentiment) as std from sentimentWHERE teamId=${teamId};`;
+    const query = `SELECT AVG(sentiment) as avg, STD(sentiment) as std from sentiment WHERE teamId='${teamId}';`;
     return getRepository(SentimentDB)
       .query(query)
       .then(result => {

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -12,13 +12,18 @@ export class SentimentService {
   private slackService = SlackService.getInstance();
   private muzzleService = new MuzzleService();
 
-  public performSentimentAnalysis(userId: string, teamId: string, text: string): void {
-    this.analyzeSentimentAndStore(userId, teamId, text).then(() => {
+  public performSentimentAnalysis(userId: string, teamId: string, channelId: string, text: string): void {
+    this.analyzeSentimentAndStore(userId, teamId, channelId, text).then(() => {
       this.autoMuzzleIfNecessary(userId, teamId);
     });
   }
 
-  public async analyzeSentimentAndStore(userId: string, teamId: string, text: string): Promise<InsertResult> {
+  public async analyzeSentimentAndStore(
+    userId: string,
+    teamId: string,
+    channelId: string,
+    text: string,
+  ): Promise<InsertResult> {
     const options: AnalysisOptions = {
       extras: {
         wtf: 0,
@@ -30,6 +35,7 @@ export class SentimentService {
     sentimentModel.sentiment = emotionalScore.comparative;
     sentimentModel.teamId = teamId;
     sentimentModel.userId = userId;
+    sentimentModel.channelId = channelId;
     return getRepository(SentimentDB).insert(sentimentModel);
   }
 

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -8,7 +8,7 @@ export class SentimentService {
 
   public performSentimentAnalysis(userId: string, teamId: string, text: string): void {
     this.analyzeSentimentAndStore(userId, teamId, text).then(() => {
-      this.autoMuzzleIfNecessary(userId, teamId, text);
+      this.autoMuzzleIfNecessary(userId, teamId);
     });
   }
 
@@ -36,7 +36,7 @@ export class SentimentService {
       });
   }
 
-  public async autoMuzzleIfNecessary(userId: string, teamId: string, text: string): Promise<void> {
+  public async autoMuzzleIfNecessary(userId: string, teamId: string): Promise<void> {
     const start = moment()
       .subtract(3, 'minutes')
       .format('YYYY-MM-DD HH:mm:ss');

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -1,0 +1,53 @@
+import moment from 'moment';
+import Sentiment, { AnalysisResult } from 'sentiment';
+import { getRepository, InsertResult } from 'typeorm';
+import { Sentiment as SentimentDB } from '../../shared/db/models/Sentiment';
+import { SuppressorService } from '../../shared/services/suppressor.service';
+
+export class SentimentService extends SuppressorService {
+  sentiment = new Sentiment();
+
+  public async performSentimentAnalysis(userId: string, teamId: string, text: string): void {
+    this.analyzeSentimentAndStore(userId, teamId, text).then(() => {
+      this.autoMuzzleIfNecessary(userId, teamId, text);
+    });
+  }
+
+  public async analyzeSentimentAndStore(userId: string, teamId: string, text: string): Promise<InsertResult> {
+    const emotionalScore: AnalysisResult = this.sentiment.analyze(text);
+    console.log('user', userId);
+    console.log('team', teamId);
+    console.log('text', text);
+    const sentimentModel = new SentimentDB();
+    sentimentModel.sentiment = emotionalScore.comparative;
+    sentimentModel.teamId = teamId;
+    sentimentModel.userId = userId;
+    return getRepository(SentimentDB).insert(sentimentModel);
+  }
+
+  getAvgSentimentForTimePeriod(userId: string, teamId: string, start: string, end: string): Promise<any> {
+    const query = `SELECT AVG(sentiment) FROM sentiment WHERE userId='${userId}' AND teamId='${teamId}' AND createdAt >= '${start}' AND createdAt < '${end}';`;
+    return getRepository(SentimentDB)
+      .query(query)
+      .then(result => {
+        console.log(result);
+        return result;
+      });
+  }
+
+  public async autoMuzzleIfNecessary(userId: string, teamId: string, text: string) {
+    const start = moment()
+      .subtract(3, 'minutes')
+      .format('YYYY-MM-DD HH:mm:ss');
+    const end = moment().format('YYYY-MM-DD HH:mm:ss');
+    const isSuppressed = await this.isSuppressed(userId, teamId);
+    if (!isSuppressed) {
+      const averageSentiment = await this.getAvgSentimentForTimePeriod(userId, teamId, start, end);
+      if (averageSentiment < 0) {
+        console.log(`${userId} should be muzzled because his sentiment analysis score was: ${averageSentiment}`);
+      } else {
+        this.analyzeSentimentAndStore(userId, teamId, text);
+      }
+    }
+  }
+}

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -2,6 +2,7 @@ import moment from 'moment';
 import Sentiment, { AnalysisOptions, AnalysisResult } from 'sentiment';
 import { getRepository, InsertResult } from 'typeorm';
 import { Sentiment as SentimentDB } from '../../shared/db/models/Sentiment';
+import { MuzzleService } from '../muzzle/muzzle.service';
 import { SlackService } from '../slack/slack.service';
 import { WebService } from '../web/web.service';
 
@@ -9,6 +10,7 @@ export class SentimentService {
   sentiment = new Sentiment();
   private webService = WebService.getInstance();
   private slackService = SlackService.getInstance();
+  private muzzleService = new MuzzleService();
 
   public performSentimentAnalysis(userId: string, teamId: string, text: string): void {
     this.analyzeSentimentAndStore(userId, teamId, text).then(() => {
@@ -70,6 +72,7 @@ export class SentimentService {
           Team Average Minus STD was ${avgMinusOneStd}.
           `,
         );
+        this.muzzleService.autoMuzzle(userId, teamId);
       });
     }
   }

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import Sentiment, { AnalysisOptions, AnalysisResult } from 'sentiment';
+import Sentiment, { AnalysisResult } from 'sentiment';
 import { getRepository, InsertResult } from 'typeorm';
 import { Sentiment as SentimentDB } from '../../shared/db/models/Sentiment';
 import { SlackService } from '../slack/slack.service';
@@ -17,14 +17,7 @@ export class SentimentService {
   }
 
   public async analyzeSentimentAndStore(userId: string, teamId: string, text: string): Promise<InsertResult> {
-    const options: AnalysisOptions = {
-      extras: {
-        fuck: 0,
-        dammit: 0,
-        damn: 0,
-      },
-    };
-    const emotionalScore: AnalysisResult = this.sentiment.analyze(text, options);
+    const emotionalScore: AnalysisResult = this.sentiment.analyze(text);
     const sentimentModel = new SentimentDB();
     sentimentModel.sentiment = emotionalScore.comparative;
     sentimentModel.teamId = teamId;

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -2,9 +2,11 @@ import moment from 'moment';
 import Sentiment, { AnalysisResult } from 'sentiment';
 import { getRepository, InsertResult } from 'typeorm';
 import { Sentiment as SentimentDB } from '../../shared/db/models/Sentiment';
+import { WebService } from '../web/web.service';
 
 export class SentimentService {
   sentiment = new Sentiment();
+  private webService = WebService.getInstance();
 
   public performSentimentAnalysis(userId: string, teamId: string, text: string): void {
     this.analyzeSentimentAndStore(userId, teamId, text).then(() => {
@@ -50,6 +52,15 @@ export class SentimentService {
     console.log('team avg minus std', avgMinusOneStd);
     if (averageSentiment?.[0]?.avg <= avgMinusOneStd && averageSentiment?.[0]?.count >= 5) {
       console.log(`${userId} should be muzzled.`);
+      this.webService.sendDebugMessage(
+        'U2YJQN2KB',
+        `${userId} should be muzzled. 
+        User Average was ${averageSentiment?.[0]?.avg}.
+        Team Average was ${avgAndStd?.[0]?.avg}.
+        Team STD was ${avgAndStd?.[0]?.std}.
+        Team Average Minus STD was ${avgMinusOneStd}.
+        `,
+      );
     }
   }
 }

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import Sentiment, { AnalysisOptions, AnalysisResult, SentimentOptions } from 'sentiment';
+import Sentiment, { AnalysisOptions, AnalysisResult } from 'sentiment';
 import { getRepository, InsertResult } from 'typeorm';
 import { Sentiment as SentimentDB } from '../../shared/db/models/Sentiment';
 import { SlackService } from '../slack/slack.service';

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -25,7 +25,7 @@ export class SentimentService {
   }
 
   getAvgSentimentForTimePeriod(userId: string, teamId: string, start: string, end: string): Promise<any> {
-    const query = `select AVG(sentiment.sentiment), COUNT(sentiment.userId), sentiment.userId, slack_user.isBot FROM sentiment INNER JOIN slack_user ON slack_user.slackId = sentiment.userId WHERE slack_user.isBot != 1 AND sentiment.userId = '${userId}' AND sentiment.teamId = '${teamId} AND sentiment.createdAt >= '${start}' AND sentiment.createdAt < '${end}' GROUP BY sentiment.userId, slack_user.isBot;`;
+    const query = `select AVG(sentiment.sentiment), COUNT(sentiment.userId), sentiment.userId, slack_user.isBot FROM sentiment INNER JOIN slack_user ON slack_user.slackId = sentiment.userId WHERE slack_user.isBot != 1 AND sentiment.userId = '${userId}' AND sentiment.teamId = '${teamId}' AND sentiment.createdAt >= '${start}' AND sentiment.createdAt < '${end}' GROUP BY sentiment.userId, slack_user.isBot;`;
     return getRepository(SentimentDB)
       .query(query)
       .then(result => {

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -14,9 +14,6 @@ export class SentimentService {
 
   public async analyzeSentimentAndStore(userId: string, teamId: string, text: string): Promise<InsertResult> {
     const emotionalScore: AnalysisResult = this.sentiment.analyze(text);
-    console.log('user', userId);
-    console.log('team', teamId);
-    console.log('text', text);
     console.log(emotionalScore);
     const sentimentModel = new SentimentDB();
     sentimentModel.sentiment = emotionalScore.comparative;

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -9,7 +9,7 @@ export class SentimentService {
     this.analyzeSentimentAndStore(userId, teamId, channelId, text);
   }
 
-  public async analyzeSentimentAndStore(
+  private async analyzeSentimentAndStore(
     userId: string,
     teamId: string,
     channelId: string,
@@ -28,19 +28,5 @@ export class SentimentService {
     sentimentModel.userId = userId;
     sentimentModel.channelId = channelId;
     return getRepository(SentimentDB).insert(sentimentModel);
-  }
-
-  getAvgSentimentForTimePeriod(userId: string, teamId: string, start: string, end: string): Promise<any> {
-    const query = `select AVG(sentiment.sentiment) as avg, COUNT(sentiment.userId) as count, sentiment.userId, slack_user.isBot FROM sentiment INNER JOIN slack_user ON slack_user.slackId = sentiment.userId WHERE slack_user.isBot != 1 AND sentiment.userId = '${userId}' AND sentiment.teamId = '${teamId}' AND sentiment.createdAt >= '${start}' AND sentiment.createdAt < '${end}' GROUP BY sentiment.userId, slack_user.isBot;`;
-    return getRepository(SentimentDB)
-      .query(query)
-      .then(result => result);
-  }
-
-  getAvgAndSTD(teamId: string): Promise<any> {
-    const query = `SELECT AVG(sentiment) as avg, STD(sentiment) as std from sentiment WHERE teamId='${teamId}';`;
-    return getRepository(SentimentDB)
-      .query(query)
-      .then(result => result);
   }
 }

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -25,7 +25,7 @@ export class SentimentService {
   }
 
   getAvgSentimentForTimePeriod(userId: string, teamId: string, start: string, end: string): Promise<any> {
-    const query = `SELECT AVG(sentiment) as avg, COUNT(*), userId FROM sentiment WHERE userId='${userId}' AND teamId='${teamId}' AND createdAt >= '${start}' AND createdAt < '${end}' GROUP BY userId;`;
+    const query = `select AVG(sentiment.sentiment), COUNT(sentiment.userId), sentiment.userId, slack_user.isBot FROM sentiment INNER JOIN slack_user ON slack_user.slackId = sentiment.userId WHERE slack_user.isBot != 1 AND sentiment.userId = '${userId}' AND sentiment.teamId = '${teamId} AND sentiment.createdAt >= '${start}' AND csentiment.reatedAt < '${end}' GROUP BY sentiment.userId, slack_user.isBot;`;
     return getRepository(SentimentDB)
       .query(query)
       .then(result => {

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import Sentiment, { AnalysisResult } from 'sentiment';
+import Sentiment, { AnalysisOptions, AnalysisResult, SentimentOptions } from 'sentiment';
 import { getRepository, InsertResult } from 'typeorm';
 import { Sentiment as SentimentDB } from '../../shared/db/models/Sentiment';
 import { SlackService } from '../slack/slack.service';
@@ -17,7 +17,13 @@ export class SentimentService {
   }
 
   public async analyzeSentimentAndStore(userId: string, teamId: string, text: string): Promise<InsertResult> {
-    const emotionalScore: AnalysisResult = this.sentiment.analyze(text);
+    const options: AnalysisOptions = {
+      extras: {
+        wtf: 0,
+        WTF: 0,
+      },
+    };
+    const emotionalScore: AnalysisResult = this.sentiment.analyze(text, options);
     const sentimentModel = new SentimentDB();
     sentimentModel.sentiment = emotionalScore.comparative;
     sentimentModel.teamId = teamId;

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -39,7 +39,7 @@ export class SentimentService {
 
   public async autoMuzzleIfNecessary(userId: string, teamId: string): Promise<void> {
     const start = moment()
-      .subtract(3, 'minutes')
+      .subtract(5, 'minutes')
       .format('YYYY-MM-DD HH:mm:ss');
     const end = moment().format('YYYY-MM-DD HH:mm:ss');
     const averageSentiment = await this.getAvgSentimentForTimePeriod(userId, teamId, start, end);

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -25,7 +25,7 @@ export class SentimentService {
   }
 
   getAvgSentimentForTimePeriod(userId: string, teamId: string, start: string, end: string): Promise<any> {
-    const query = `select AVG(sentiment.sentiment), COUNT(sentiment.userId), sentiment.userId, slack_user.isBot FROM sentiment INNER JOIN slack_user ON slack_user.slackId = sentiment.userId WHERE slack_user.isBot != 1 AND sentiment.userId = '${userId}' AND sentiment.teamId = '${teamId} AND sentiment.createdAt >= '${start}' AND csentiment.reatedAt < '${end}' GROUP BY sentiment.userId, slack_user.isBot;`;
+    const query = `select AVG(sentiment.sentiment), COUNT(sentiment.userId), sentiment.userId, slack_user.isBot FROM sentiment INNER JOIN slack_user ON slack_user.slackId = sentiment.userId WHERE slack_user.isBot != 1 AND sentiment.userId = '${userId}' AND sentiment.teamId = '${teamId} AND sentiment.createdAt >= '${start}' AND sentiment.createdAt < '${end}' GROUP BY sentiment.userId, slack_user.isBot;`;
     return getRepository(SentimentDB)
       .query(query)
       .then(result => {

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -13,9 +13,7 @@ export class SentimentService {
   private muzzleService = new MuzzleService();
 
   public performSentimentAnalysis(userId: string, teamId: string, channelId: string, text: string): void {
-    this.analyzeSentimentAndStore(userId, teamId, channelId, text).then(() => {
-      this.autoMuzzleIfNecessary(userId, teamId);
-    });
+    this.analyzeSentimentAndStore(userId, teamId, channelId, text);
   }
 
   public async analyzeSentimentAndStore(
@@ -53,6 +51,7 @@ export class SentimentService {
       .then(result => result);
   }
 
+  // Unused - keeping in case we want to bring this back.
   public async autoMuzzleIfNecessary(userId: string, teamId: string): Promise<void> {
     const start = moment()
       .subtract(5, 'minutes')

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -34,6 +34,7 @@ export class SentimentService {
       .query(query)
       .then(result => {
         console.log(result);
+        return result;
       });
   }
 

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import Sentiment, { AnalysisResult } from 'sentiment';
+import Sentiment, { AnalysisOptions, AnalysisResult } from 'sentiment';
 import { getRepository, InsertResult } from 'typeorm';
 import { Sentiment as SentimentDB } from '../../shared/db/models/Sentiment';
 import { SlackService } from '../slack/slack.service';
@@ -17,7 +17,14 @@ export class SentimentService {
   }
 
   public async analyzeSentimentAndStore(userId: string, teamId: string, text: string): Promise<InsertResult> {
-    const emotionalScore: AnalysisResult = this.sentiment.analyze(text);
+    const options: AnalysisOptions = {
+      extras: {
+        fuck: 0,
+        dammit: 0,
+        damn: 0,
+      },
+    };
+    const emotionalScore: AnalysisResult = this.sentiment.analyze(text, options);
     const sentimentModel = new SentimentDB();
     sentimentModel.sentiment = emotionalScore.comparative;
     sentimentModel.teamId = teamId;

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -2,11 +2,13 @@ import moment from 'moment';
 import Sentiment, { AnalysisResult } from 'sentiment';
 import { getRepository, InsertResult } from 'typeorm';
 import { Sentiment as SentimentDB } from '../../shared/db/models/Sentiment';
+import { SlackService } from '../slack/slack.service';
 import { WebService } from '../web/web.service';
 
 export class SentimentService {
   sentiment = new Sentiment();
   private webService = WebService.getInstance();
+  private slackService = SlackService.getInstance();
 
   public performSentimentAnalysis(userId: string, teamId: string, text: string): void {
     this.analyzeSentimentAndStore(userId, teamId, text).then(() => {
@@ -52,15 +54,17 @@ export class SentimentService {
     console.log('team avg minus std', avgMinusOneStd);
     if (averageSentiment?.[0]?.avg <= avgMinusOneStd && averageSentiment?.[0]?.count >= 5) {
       console.log(`${userId} should be muzzled.`);
-      this.webService.sendDebugMessage(
-        'U2YJQN2KB',
-        `${userId} should be muzzled. 
-        User Average was ${averageSentiment?.[0]?.avg}.
-        Team Average was ${avgAndStd?.[0]?.avg}.
-        Team STD was ${avgAndStd?.[0]?.std}.
-        Team Average Minus STD was ${avgMinusOneStd}.
-        `,
-      );
+      this.slackService.getUserById(userId, teamId).then(user => {
+        this.webService.sendDebugMessage(
+          'U2YJQN2KB',
+          `${user?.name} should be muzzled. 
+          User Average was ${averageSentiment?.[0]?.avg}.
+          Team Average was ${avgAndStd?.[0]?.avg}.
+          Team STD was ${avgAndStd?.[0]?.std}.
+          Team Average Minus STD was ${avgMinusOneStd}.
+          `,
+        );
+      });
     }
   }
 }

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -41,6 +41,7 @@ export class SentimentService {
     const end = moment().format('YYYY-MM-DD HH:mm:ss');
     const averageSentiment = await this.getAvgSentimentForTimePeriod(userId, teamId, start, end);
     console.log(averageSentiment);
+    console.log(text);
     // if (averageSentiment < 0) {
     //   console.log(`${userId} should be muzzled because his sentiment analysis score was: ${averageSentiment}`);
     // }

--- a/src/services/sentiment/sentiment.service.ts
+++ b/src/services/sentiment/sentiment.service.ts
@@ -32,10 +32,7 @@ export class SentimentService {
     const query = `SELECT AVG(sentiment) as avg, STD(sentiment) as std from sentiment WHERE teamId='${teamId}';`;
     return getRepository(SentimentDB)
       .query(query)
-      .then(result => {
-        console.log(result);
-        return result;
-      });
+      .then(result => result);
   }
 
   public async autoMuzzleIfNecessary(userId: string, teamId: string): Promise<void> {
@@ -46,6 +43,7 @@ export class SentimentService {
     const averageSentiment = await this.getAvgSentimentForTimePeriod(userId, teamId, start, end);
     const avgAndStd = await this.getAvgAndSTD(teamId);
     const avgMinusOneStd = avgAndStd?.[0]?.avg - avgAndStd?.[0]?.std;
+    console.log(averageSentiment);
     console.log('user avg', averageSentiment?.[0]?.avg);
     console.log('team std', avgAndStd?.[0]?.std);
     console.log('team avg', avgAndStd?.[0]?.avg);

--- a/src/services/slack/slack.persistence.service.ts
+++ b/src/services/slack/slack.persistence.service.ts
@@ -71,6 +71,10 @@ export class SlackPersistenceService {
     return getRepository(SlackUser).findOne({ slackId: userId, teamId });
   }
 
+  async getUserByUserName(username: string, teamId: string): Promise<SlackUser | undefined> {
+    return getRepository(SlackUser).findOne({ name: username, teamId });
+  }
+
   async getBotByBotId(botId: string, teamId: string): Promise<SlackUser | undefined> {
     return getRepository(SlackUser).findOne({ botId, teamId });
   }

--- a/src/services/slack/slack.service.ts
+++ b/src/services/slack/slack.service.ts
@@ -34,6 +34,10 @@ export class SlackService {
     return regArray ? regArray[0].slice(2) : '';
   }
 
+  public getUserIdByName(userName: string, teamId: string): Promise<string | undefined> {
+    return this.persistenceService.getUserByUserName(userName, teamId).then(user => user?.slackId);
+  }
+
   /**
    * Returns the user name by id
    */

--- a/src/services/web/web.service.ts
+++ b/src/services/web/web.service.ts
@@ -49,7 +49,7 @@ export class WebService {
 
   public sendDebugMessage(userId: string, text: string) {
     const options: ChatPostEphemeralArguments = {
-      channel: '#testbotz',
+      channel: userId,
       text,
       user: userId,
     };

--- a/src/services/web/web.service.ts
+++ b/src/services/web/web.service.ts
@@ -47,6 +47,15 @@ export class WebService {
     });
   }
 
+  public sendDebugMessage(userId: string, text: string) {
+    const options: ChatPostEphemeralArguments = {
+      channel: '#testbotz',
+      text,
+      user: userId,
+    };
+    return this.web.chat.postEphemeral(options);
+  }
+
   /**
    * Handles sending messages to the chat.
    */

--- a/src/shared/db/models/Sentiment.ts
+++ b/src/shared/db/models/Sentiment.ts
@@ -5,7 +5,7 @@ export class Sentiment {
   @PrimaryGeneratedColumn()
   public id!: number;
 
-  @Column({ default: null })
+  @Column()
   public userId!: string;
 
   @Column()

--- a/src/shared/db/models/Sentiment.ts
+++ b/src/shared/db/models/Sentiment.ts
@@ -5,7 +5,7 @@ export class Sentiment {
   @PrimaryGeneratedColumn()
   public id!: number;
 
-  @Column()
+  @Column({ default: null })
   public userId!: string;
 
   @Column()

--- a/src/shared/db/models/Sentiment.ts
+++ b/src/shared/db/models/Sentiment.ts
@@ -11,6 +11,9 @@ export class Sentiment {
   @Column()
   public teamId!: string;
 
+  @Column({ default: null })
+  public channelId!: string;
+
   @Column({ type: 'decimal', precision: 5, scale: 2 })
   public sentiment!: number;
 

--- a/src/shared/db/models/Sentiment.ts
+++ b/src/shared/db/models/Sentiment.ts
@@ -1,0 +1,19 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Sentiment {
+  @PrimaryGeneratedColumn()
+  public id!: number;
+
+  @Column()
+  public userId!: string;
+
+  @Column()
+  public teamId!: string;
+
+  @Column()
+  public sentiment!: number;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  public createdAt!: Date;
+}

--- a/src/shared/db/models/Sentiment.ts
+++ b/src/shared/db/models/Sentiment.ts
@@ -11,7 +11,7 @@ export class Sentiment {
   @Column()
   public teamId!: string;
 
-  @Column()
+  @Column({ type: 'decimal', precision: 5, scale: 2 })
   public sentiment!: number;
 
   @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -109,7 +109,7 @@ export class SuppressorService {
       if (request.event.blocks) {
         const userId = this.findUserIdInBlocks(request.event.blocks, USER_ID_REGEX);
         const userName = await this.findUserInBlocks(request.event.blocks);
-        console.log('ID found for spoiler muzzle:' + userName);
+
         if (userId) {
           userIdByBlocks = this.slackService.getUserId(userId);
         }


### PR DESCRIPTION
- Added sentiment analysis service, db model and sentiment npm package. Will need to revisit this post-refactor of muzzle, backfire, and counter services.
- Added GROUP BY the query
- Added useless log to avoid ts error
- Fixes to getAvgSentimentForTimePeriod to exclude bots
- Fixed typo
- More typo fixing
- Small logging changes
- REmoved unnecessary param
- Changed sentiment to be decimal to avoid rounding issues
- Removed unnecessry logs
- Added some new logic and removed old logs
- Fixed query
- Added retunr
- More logging
- Added debug message
- Accounted for last 5 minutes
- Added way to get user id for easier debugging
- Changed debug message to message me
- Added default null for userid
- Added isReaction filter for sentiment analysis
- Added some curse word overrides
- Added default null for userId in sentiment
- Added logging
- Adjusted WTF to represent 0
- Removed bad import
- Added ability to automuzzle
- Added channelId field
