### PR TITLE
Add Name to Define and Changes to Defintion Structure

### DIFF
--- a/fun-fact-job/fun-fact-job.py
+++ b/fun-fact-job/fun-fact-job.py
@@ -29,7 +29,7 @@ def getFacts(ctx):
 
 def getQuote():
   url = random.choice(quotes)
-  quote = requests.get(url["url"])
+  quote = requests.get(url["url"], verify=False)
   asJson = quote.json()
   print(asJson)
   return { 
@@ -39,9 +39,9 @@ def getQuote():
 def getFact():
   url = random.choice(urls)
   if ("headers" in url):
-    fact = requests.get(url["url"], headers=url["headers"])
+    fact = requests.get(url["url"], headers=url["headers"], verify=False)
   else:
-    fact = requests.get(url["url"])
+    fact = requests.get(url["url"], verify=False)
   
   if (fact):
     asJson = fact.json()

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "nodemon": "^1.19.0",
         "prettier": "^1.17.1",
         "ts-jest": "^26.3.0",
-        "ts-node": "^8.1.0"
+        "ts-node": "^10.4.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -464,6 +464,27 @@
       },
       "engines": {
         "node": ">=0.1.95"
+      }
+    },
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -2286,6 +2307,30 @@
       "dependencies": {
         "follow-redirects": "1.5.10"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.9",
@@ -4119,6 +4164,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "6.0.5",
@@ -14076,25 +14127,65 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
-      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
       "dev": true,
       "dependencies": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
+        "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
         "yn": "3.1.1"
       },
       "bin": {
         "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
         "ts-node-script": "dist/bin-script.js",
         "ts-node-transpile-only": "dist/bin-transpile.js",
         "ts-script": "dist/bin-script-deprecated.js"
       },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/tslib": {
@@ -15442,6 +15533,21 @@
       "requires": {
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
+      }
+    },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -16910,6 +17016,30 @@
           }
         }
       }
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.9",
@@ -18445,6 +18575,12 @@
       "requires": {
         "capture-stack-trace": "^1.0.0"
       }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -26426,16 +26562,37 @@
       }
     },
     "ts-node": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
-      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
       "dev": true,
       "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
+        "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
         "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+          "dev": true
+        },
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true
+        }
       }
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "nodemon": "^1.19.0",
     "prettier": "^1.17.1",
     "ts-jest": "^26.3.0",
-    "ts-node": "^8.1.0"
+    "ts-node": "^10.4.0"
   },
   "husky": {
     "hooks": {

--- a/src/controllers/define.controller.ts
+++ b/src/controllers/define.controller.ts
@@ -48,7 +48,7 @@ defineController.post('/define', async (req: Request, res: Response) => {
         elements: [
           {
             type: 'mrkdwn',
-            text: `:sparkles: Definition requested by <@${request.user_id}>, and provided by users just like you. :sparkles:`,
+            text: `:sparkles: _Definition requested by <@${request.user_id}>, and provided by users just like you._ :sparkles:`,
           },
         ],
       });

--- a/src/controllers/define.controller.ts
+++ b/src/controllers/define.controller.ts
@@ -1,3 +1,4 @@
+import { KnownBlock } from '@slack/web-api';
 import express, { Request, Response, Router } from 'express';
 import { DefineService } from '../services/define/define.service';
 import { WebService } from '../services/web/web.service';
@@ -23,7 +24,7 @@ defineController.post('/define', async (req: Request, res: Response) => {
       res.status(200).send();
       const text = `*${defineService.capitalizeFirstLetter(request.text)}*`;
       const definitions = defineService.formatDefs(defined.list, request.text);
-      const blocks = [
+      const blocks: KnownBlock[] = [
         {
           type: 'header',
           text: {
@@ -31,23 +32,20 @@ defineController.post('/define', async (req: Request, res: Response) => {
             text,
           },
         },
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: definitions,
-          },
-        },
-        {
-          type: 'context',
-          elements: [
-            {
-              type: 'mrkdwn',
-              text: `Definition requested by <$${request.user_id}>`,
-            },
-          ],
-        },
       ];
+
+      definitions.map(def => blocks.push(def));
+
+      blocks.push({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `Definition requested by <@${request.user_id}>`,
+          },
+        ],
+      });
+
       webService.sendMessage(request.channel_id, text, blocks);
     }
   }

--- a/src/controllers/define.controller.ts
+++ b/src/controllers/define.controller.ts
@@ -48,7 +48,7 @@ defineController.post('/define', async (req: Request, res: Response) => {
         elements: [
           {
             type: 'mrkdwn',
-            text: `Definition requested by <@${request.user_id}>`,
+            text: `:sparkles: _Definition requested by <@${request.user_id}>, and provided by users just like you. :sparkles:`,
           },
         ],
       });

--- a/src/controllers/define.controller.ts
+++ b/src/controllers/define.controller.ts
@@ -1,13 +1,13 @@
 import express, { Request, Response, Router } from 'express';
 import { DefineService } from '../services/define/define.service';
-import { SlackService } from '../services/slack/slack.service';
+import { WebService } from '../services/web/web.service';
 import { UrbanDictionaryResponse } from '../shared/models/define/define-models';
-import { ChannelResponse, SlashCommandRequest } from '../shared/models/slack/slack-models';
+import { SlashCommandRequest } from '../shared/models/slack/slack-models';
 import { SuppressorService } from '../shared/services/suppressor.service';
 
 export const defineController: Router = express.Router();
 const suppressorService = new SuppressorService();
-const slackService = SlackService.getInstance();
+const webService = WebService.getInstance();
 const defineService = DefineService.getInstance();
 
 defineController.post('/define', async (req: Request, res: Response) => {
@@ -21,13 +21,34 @@ defineController.post('/define', async (req: Request, res: Response) => {
       res.send('Something went wrong while retrieving your definition');
     } else {
       res.status(200).send();
-      const response: ChannelResponse = {
-        // eslint-disable-next-line @typescript-eslint/camelcase
-        response_type: 'in_channel',
-        text: `*${defineService.capitalizeFirstLetter(request.text)}*`,
-        attachments: defineService.formatDefs(defined.list, request.text),
-      };
-      slackService.sendResponse(request.response_url, response);
+      const text = `*${defineService.capitalizeFirstLetter(request.text)}*`;
+      const definitions = defineService.formatDefs(defined.list, request.text);
+      const blocks = [
+        {
+          type: 'header',
+          text: {
+            type: 'plain_text',
+            text,
+          },
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: definitions,
+          },
+        },
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: `Definition requested by <$${request.user_id}>`,
+            },
+          ],
+        },
+      ];
+      webService.sendMessage(request.channel_id, text, blocks);
     }
   }
 });

--- a/src/controllers/define.controller.ts
+++ b/src/controllers/define.controller.ts
@@ -32,9 +32,6 @@ defineController.post('/define', async (req: Request, res: Response) => {
             text,
           },
         },
-        {
-          type: 'divider',
-        },
       ];
 
       definitions.map(def => blocks.push(def));

--- a/src/controllers/define.controller.ts
+++ b/src/controllers/define.controller.ts
@@ -32,6 +32,9 @@ defineController.post('/define', async (req: Request, res: Response) => {
             text,
           },
         },
+        {
+          type: 'divider',
+        },
       ];
 
       definitions.map(def => blocks.push(def));
@@ -45,6 +48,8 @@ defineController.post('/define', async (req: Request, res: Response) => {
           },
         ],
       });
+
+      console.log(blocks);
 
       webService.sendMessage(request.channel_id, text, blocks);
     }

--- a/src/controllers/define.controller.ts
+++ b/src/controllers/define.controller.ts
@@ -48,7 +48,7 @@ defineController.post('/define', async (req: Request, res: Response) => {
         elements: [
           {
             type: 'mrkdwn',
-            text: `:sparkles: _Definition requested by <@${request.user_id}>, and provided by users just like you._ :sparkles:`,
+            text: `:sparkles: Definition requested by <@${request.user_id}>, and provided by users just like you. :sparkles:`,
           },
         ],
       });

--- a/src/controllers/define.controller.ts
+++ b/src/controllers/define.controller.ts
@@ -22,7 +22,7 @@ defineController.post('/define', async (req: Request, res: Response) => {
       res.send('Something went wrong while retrieving your definition');
     } else {
       res.status(200).send();
-      const text = `*${defineService.capitalizeFirstLetter(request.text)}*`;
+      const text = `${defineService.capitalizeFirstLetter(request.text)}`;
       const definitions = defineService.formatDefs(defined.list, request.text);
       const blocks: KnownBlock[] = [
         {

--- a/src/controllers/define.controller.ts
+++ b/src/controllers/define.controller.ts
@@ -48,7 +48,7 @@ defineController.post('/define', async (req: Request, res: Response) => {
         elements: [
           {
             type: 'mrkdwn',
-            text: `:sparkles: _Definition requested by <@${request.user_id}>, and provided by users just like you. :sparkles:`,
+            text: `:sparkles: _Definition requested by <@${request.user_id}>, and provided by users just like you._ :sparkles:`,
           },
         ],
       });

--- a/src/controllers/define.controller.ts
+++ b/src/controllers/define.controller.ts
@@ -40,6 +40,10 @@ defineController.post('/define', async (req: Request, res: Response) => {
       definitions.map(def => blocks.push(def));
 
       blocks.push({
+        type: 'divider',
+      });
+
+      blocks.push({
         type: 'context',
         elements: [
           {

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -71,6 +71,7 @@ async function handleBackfire(request: EventRequest): Promise<void> {
   const userName = await slackService.getUserNameById(request.event.user, request.team_id);
   if (!containsTag) {
     console.log(`${userName} | ${request.event.user} is backfired! Suppressing his voice...`);
+    webService.deleteMessage(request.event.channel, request.event.ts);
     backfireService.sendBackfiredMessage(
       request.event.channel,
       request.event.user,

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -37,6 +37,7 @@ async function handleMuzzledMessage(request: EventRequest): Promise<void> {
 
   if (!containsTag) {
     console.log(`${userName} | ${request.event.user} is muzzled! Suppressing his voice...`);
+    webService.deleteMessage(request.event.channel, request.event.ts);
     muzzleService.sendMuzzledMessage(
       request.event.channel,
       request.event.user,

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -37,7 +37,7 @@ async function handleMuzzledMessage(request: EventRequest): Promise<void> {
 
   if (!containsTag) {
     console.log(`${userName} | ${request.event.user} is muzzled! Suppressing his voice...`);
-    webService.deleteMessage(request.event.channel, request.event.ts);
+    webService.deleteMessage(request.event.channel, request.event.ts, request.event.user);
     muzzleService.sendMuzzledMessage(
       request.event.channel,
       request.event.user,
@@ -52,7 +52,7 @@ async function handleMuzzledMessage(request: EventRequest): Promise<void> {
         `${userName} attempted to tag someone or change the channel topic. Muzzle increased by ${ABUSE_PENALTY_TIME}!`,
       );
       muzzlePersistenceService.addMuzzleTime(request.event.user, request.team_id, ABUSE_PENALTY_TIME);
-      webService.deleteMessage(request.event.channel, request.event.ts);
+      webService.deleteMessage(request.event.channel, request.event.ts, request.event.user);
       muzzlePersistenceService.trackDeletedMessage(+muzzleId, request.event.text);
       webService.sendMessage(
         request.event.channel,
@@ -71,7 +71,7 @@ async function handleBackfire(request: EventRequest): Promise<void> {
   const userName = await slackService.getUserNameById(request.event.user, request.team_id);
   if (!containsTag) {
     console.log(`${userName} | ${request.event.user} is backfired! Suppressing his voice...`);
-    webService.deleteMessage(request.event.channel, request.event.ts);
+    webService.deleteMessage(request.event.channel, request.event.ts, request.event.user);
     backfireService.sendBackfiredMessage(
       request.event.channel,
       request.event.user,
@@ -83,7 +83,7 @@ async function handleBackfire(request: EventRequest): Promise<void> {
     const backfireId = backfireService.getBackfire(request.event.user, request.team_id);
     console.log(`${userName} attempted to tag someone. Backfire increased by ${ABUSE_PENALTY_TIME}!`);
     backfireService.addBackfireTime(request.event.user, request.team_id, ABUSE_PENALTY_TIME);
-    webService.deleteMessage(request.event.channel, request.event.ts);
+    webService.deleteMessage(request.event.channel, request.event.ts, request.event.user);
     backfireService.trackDeletedMessage(+backfireId, request.event.text);
     webService.sendMessage(
       request.event.channel,
@@ -108,7 +108,7 @@ async function handleCounterMuzzle(request: EventRequest): Promise<void> {
   } else if (containsTag && (!request.event.subtype || request.event.subtype === 'channel_topic')) {
     console.log(`${userName} attempted to tag someone. Counter Muzzle increased by ${ABUSE_PENALTY_TIME}!`);
     counterPersistenceService.addCounterMuzzleTime(request.event.user, ABUSE_PENALTY_TIME);
-    webService.deleteMessage(request.event.channel, request.event.ts);
+    webService.deleteMessage(request.event.channel, request.event.ts, request.event.user);
     webService.sendMessage(
       request.event.channel,
       `:rotating_light: <@${request.event.user}> attempted to @ while countered! Muzzle increased by ${getTimeString(
@@ -120,7 +120,7 @@ async function handleCounterMuzzle(request: EventRequest): Promise<void> {
 
 async function handleBotMessage(request: EventRequest, botUserToMuzzle: string): Promise<void> {
   console.log(`A user is muzzled and tried to send a bot message! Suppressing...`);
-  webService.deleteMessage(request.event.channel, request.event.ts);
+  webService.deleteMessage(request.event.channel, request.event.ts, request.event.user);
   const muzzleId: string | null = await muzzlePersistenceService.getMuzzle(botUserToMuzzle, request.team_id);
   if (muzzleId) {
     muzzlePersistenceService.trackDeletedMessage(+muzzleId, 'A bot message');
@@ -146,7 +146,7 @@ async function handleBotMessage(request: EventRequest, botUserToMuzzle: string):
 
 function deleteMessage(request: EventRequest): void {
   console.log('Someone talked in #hot who was not a bot. Suppressing...');
-  webService.deleteMessage(request.event.channel, request.event.ts);
+  webService.deleteMessage(request.event.channel, request.event.ts, request.event.user);
 }
 
 function handleReaction(request: EventRequest): void {

--- a/src/services/activity/activity.persistence.service.ts
+++ b/src/services/activity/activity.persistence.service.ts
@@ -44,8 +44,29 @@ export class ActivityPersistenceService {
         for (let i = 0; i < hottest.length; i++) {
           text += `\n<#${hottest[i].channel}> : ${this.getEmoji(hottest.length - i)}`;
         }
+        const timestamp = Math.floor(new Date().getTime() / 1000);
+        const blocks = [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text,
+            },
+          },
+          {
+            type: 'context',
+            elements: [
+              {
+                type: 'mrkdwn',
+                text: `<!date^${timestamp}^Posted {date_num} {time_secs}|Posted at some point today>`,
+                verbatim: false,
+              },
+            ],
+          },
+        ];
+
         await this.web
-          .sendBlockMessage('#hot', text)
+          .sendMessage('#hot', text, blocks)
           .then((result: WebAPICallResult) => result.ts as string)
           .catch(e => {
             console.error(e);

--- a/src/services/backfire/backfire.service.ts
+++ b/src/services/backfire/backfire.service.ts
@@ -20,6 +20,7 @@ export class BackfireService extends SuppressorService {
         this.backfirePersistenceService.addSuppression(userId, teamId);
         this.sendSuppressedMessage(channel, userId, text, timestamp, +backfireId, this.backfirePersistenceService);
       } else {
+        this.webService.deleteMessage(channel, timestamp);
         this.backfirePersistenceService.trackDeletedMessage(+backfireId, text);
       }
     }

--- a/src/services/backfire/backfire.service.ts
+++ b/src/services/backfire/backfire.service.ts
@@ -20,7 +20,7 @@ export class BackfireService extends SuppressorService {
         this.backfirePersistenceService.addSuppression(userId, teamId);
         this.sendSuppressedMessage(channel, userId, text, timestamp, +backfireId, this.backfirePersistenceService);
       } else {
-        this.webService.deleteMessage(channel, timestamp);
+        this.webService.deleteMessage(channel, timestamp, userId);
         this.backfirePersistenceService.trackDeletedMessage(+backfireId, text);
       }
     }

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -66,7 +66,11 @@ export class DefineService {
       if (defArr[i].word.toLowerCase() === definedWord.toLowerCase()) {
         const carriageAndNewLine = /(\r\n)/g;
         const replaceBracket = /[\[\]]/g;
-        const definition = defArr[i].definition.replace(carriageAndNewLine, '\n>\n> ').replace(replaceBracket, '');
+        const newLineNewLine = /(\n\n)/g;
+        const definition = defArr[i].definition
+          .replace(newLineNewLine, '')
+          .replace(carriageAndNewLine, '\n> ')
+          .replace(replaceBracket, '');
 
         blocks.push({
           type: 'section',

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -64,7 +64,7 @@ export class DefineService {
       if (defArr[i].word.toLowerCase() === definedWord.toLowerCase()) {
         const carriageAndNewLine = /(\r\n)/g;
         const replaceBracket = /[\[\]]/g;
-        const definition = defArr[i].definition.replace(carriageAndNewLine, '\n\n> ').replace(replaceBracket, '');
+        const definition = defArr[i].definition.replace(carriageAndNewLine, '\n>\n> ').replace(replaceBracket, '');
 
         blocks.push({
           type: 'section',

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -51,7 +51,7 @@ export class DefineService {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: 'Sorry, no definitions found.',
+          text: '> Sorry, no definitions found.',
         },
       },
     ];

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -76,7 +76,7 @@ export class DefineService {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `> ${`${i + 1}. ${this.capitalizeFirstLetter(definition)}`}`,
+            text: `> ${`${i + 1}. ${this.capitalizeFirstLetter(definition, false)}`}`,
           },
         });
       }

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -62,8 +62,8 @@ export class DefineService {
 
     for (let i = 0; i < defArr.length; i++) {
       if (defArr[i].word.toLowerCase() === definedWord.toLowerCase()) {
-        const replaceNewLine = new RegExp('/\r\ng');
-        const replaceBracket = new RegExp('/[]g');
+        const replaceNewLine = /\r\ng/;
+        const replaceBracket = /[]g/;
         const definition = defArr[i].definition.replace(replaceNewLine, '\n\n<').replace(replaceBracket, '');
 
         blocks.push({

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -68,7 +68,7 @@ export class DefineService {
         const definition = defArr[i].definition
           .replace(carriageReturn, '')
           .replace(replaceBracket, '')
-          .replace(newLine, '\n\n<');
+          .replace(newLine, '\n\n>');
 
         blocks.push({
           type: 'section',

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -62,13 +62,16 @@ export class DefineService {
 
     for (let i = 0; i < defArr.length; i++) {
       if (defArr[i].word.toLowerCase() === definedWord.toLowerCase()) {
+        const definition = defArr[i].definition
+          .replace('\r', '')
+          .replace('\n', '\n\n>')
+          .replace('[', '')
+          .replace(']', '');
         blocks.push({
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `> ${this.formatUrbanD(
-              `${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition.replace('\r\n', '\n\n>'), false)}`,
-            )}`,
+            text: `> ${`${i + 1}. ${this.capitalizeFirstLetter(definition)}`}`,
           },
         });
       }
@@ -79,18 +82,5 @@ export class DefineService {
     }
 
     return blocks;
-  }
-  /**
-   * Takes in a definition and removes brackets.
-   */
-  private formatUrbanD(definition: string): string {
-    console.log(definition);
-    let formattedDefinition = '';
-    for (const letter of definition) {
-      if (letter !== '[' && letter !== ']') {
-        formattedDefinition += letter;
-      }
-    }
-    return formattedDefinition;
   }
 }

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -66,9 +66,9 @@ export class DefineService {
         const replaceBracket = /[\[\]]/g;
         const newLine = /\n/g;
         const definition = defArr[i].definition
-          .replace(carriageReturn, '')
-          .replace(replaceBracket, '')
-          .replace(newLine, '\n\n- ');
+          .replace(newLine, '')
+          .replace(carriageReturn, '\n\n')
+          .replace(replaceBracket, '');
 
         blocks.push({
           type: 'section',

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -46,16 +46,18 @@ export class DefineService {
    * Takes in an array of definitions and breaks them down into a shortened list depending on maxDefs
    */
   public formatDefs(defArr: Definition[], definedWord: string, maxDefs = 3): KnownBlock[] {
-    if (!defArr || defArr.length === 0) {
-      return [
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: 'Sorry, no definitions found.',
-          },
+    const noDefFound: KnownBlock[] = [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: 'Sorry, no definitions found.',
         },
-      ];
+      },
+    ];
+
+    if (!defArr || defArr.length === 0) {
+      return noDefFound;
     }
 
     const blocks: KnownBlock[] = [];
@@ -80,6 +82,6 @@ export class DefineService {
       }
     }
 
-    return blocks;
+    return blocks.length > 0 ? blocks : noDefFound;
   }
 }

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -68,13 +68,13 @@ export class DefineService {
         const definition = defArr[i].definition
           .replace(carriageReturn, '')
           .replace(replaceBracket, '')
-          .replace(newLine, '\n\n>');
+          .replace(newLine, '\n\n- ');
 
         blocks.push({
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `${`${i + 1}. ${this.capitalizeFirstLetter(definition)}`}`,
+            text: `> ${`${i + 1}. ${this.capitalizeFirstLetter(definition)}`}`,
           },
         });
       }

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -64,11 +64,7 @@ export class DefineService {
       if (defArr[i].word.toLowerCase() === definedWord.toLowerCase()) {
         const carriageAndNewLine = /(\r\n)/g;
         const replaceBracket = /[\[\]]/g;
-        const newLineFollowedByChar = /\n(.)/g;
-        const definition = defArr[i].definition
-          .replace(carriageAndNewLine, '\n')
-          .replace(replaceBracket, '')
-          .replace(newLineFollowedByChar, '\n >');
+        const definition = defArr[i].definition.replace(carriageAndNewLine, '\n> ').replace(replaceBracket, '');
 
         blocks.push({
           type: 'section',

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -62,9 +62,13 @@ export class DefineService {
 
     for (let i = 0; i < defArr.length; i++) {
       if (defArr[i].word.toLowerCase() === definedWord.toLowerCase()) {
-        const replaceNewLine = /\r\ng/;
-        const replaceBracket = /[]g/;
-        const definition = defArr[i].definition.replace(replaceNewLine, '\n\n<').replace(replaceBracket, '');
+        const carriageReturn = /\r/g;
+        const replaceBracket = /[\[\]]/g;
+        const newLine = /\n/g;
+        const definition = defArr[i].definition
+          .replace(carriageReturn, '')
+          .replace(replaceBracket, '')
+          .replace(newLine, '\n\n<');
 
         blocks.push({
           type: 'section',

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -66,7 +66,9 @@ export class DefineService {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `> ${this.formatUrbanD(`${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition, false)}`)}`,
+            text: `> ${this.formatUrbanD(
+              `${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition, false).replace('\r\n', '\n')}`,
+            )}`,
           },
         });
       }

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -76,12 +76,12 @@ export class DefineService {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `> ${`${i + 1}. ${this.capitalizeFirstLetter(definition, false)}`}`,
+            text: `> ${`${blocks.length + 1}. ${this.capitalizeFirstLetter(definition, false)}`}`,
           },
         });
       }
 
-      if (i === maxDefs - 1) {
+      if (blocks.length === maxDefs) {
         return blocks;
       }
     }

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -66,7 +66,9 @@ export class DefineService {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `> ${this.formatUrbanD(`${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition, false)}`)}`,
+            text: `> ${this.formatUrbanD(
+              `${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition.replace('\r\n', '\n'), false)}`,
+            )}`,
           },
         });
       }

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -67,7 +67,7 @@ export class DefineService {
           text: {
             type: 'mrkdwn',
             text: `> ${this.formatUrbanD(
-              `${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition.replace('\r\n', '\n'), false)}`,
+              `${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition.replace('\r\n', '  '), false)}`,
             )}`,
           },
         });

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -62,13 +62,13 @@ export class DefineService {
 
     for (let i = 0; i < defArr.length; i++) {
       if (defArr[i].word.toLowerCase() === definedWord.toLowerCase()) {
-        const carriageReturn = /\r/g;
+        const carriageAndNewLine = /(\r\n)/g;
         const replaceBracket = /[\[\]]/g;
-        const newLine = /\n/g;
+        const newLineFollowedByChar = /\n(.)/g;
         const definition = defArr[i].definition
-          .replace(newLine, '')
-          .replace(carriageReturn, '\n\n >')
-          .replace(replaceBracket, '');
+          .replace(carriageAndNewLine, '\n')
+          .replace(replaceBracket, '')
+          .replace(newLineFollowedByChar, '\n >');
 
         blocks.push({
           type: 'section',

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -1,3 +1,4 @@
+import { KnownBlock } from '@slack/web-api';
 import Axios, { AxiosResponse } from 'axios';
 import { Definition, UrbanDictionaryResponse } from '../../shared/models/define/define-models';
 
@@ -44,26 +45,38 @@ export class DefineService {
   /**
    * Takes in an array of definitions and breaks them down into a shortened list depending on maxDefs
    */
-  public formatDefs(defArr: Definition[], definedWord: string, maxDefs = 3): string {
+  public formatDefs(defArr: Definition[], definedWord: string, maxDefs = 3): KnownBlock[] {
     if (!defArr || defArr.length === 0) {
-      return 'Sorry, no definitions found.';
+      return [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: 'Sorry, no definitions found.',
+          },
+        },
+      ];
     }
 
-    let definitions = '';
+    const blocks: KnownBlock[] = [];
 
     for (let i = 0; i < defArr.length; i++) {
       if (defArr[i].word.toLowerCase() === definedWord.toLowerCase()) {
-        definitions += `${this.formatUrbanD(
-          `${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition, false)}`,
-        )} \n`;
+        blocks.push({
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `> ${this.formatUrbanD(`${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition, false)}`)}`,
+          },
+        });
       }
 
       if (i === maxDefs - 1) {
-        return definitions;
+        return blocks;
       }
     }
 
-    return definitions.length ? definitions : 'Sorry, no definitions found.';
+    return blocks;
   }
   /**
    * Takes in a definition and removes brackets.

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -74,7 +74,7 @@ export class DefineService {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `> ${`${i + 1}. ${this.capitalizeFirstLetter(definition)}`}`,
+            text: `${`${i + 1}. ${this.capitalizeFirstLetter(definition)}`}`,
           },
         });
       }

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -62,10 +62,9 @@ export class DefineService {
 
     for (let i = 0; i < defArr.length; i++) {
       if (defArr[i].word.toLowerCase() === definedWord.toLowerCase()) {
-        const definition = defArr[i].definition
-          .replaceAll('\r\n', '\n\n<')
-          .replaceAll('[', '')
-          .replaceAll(']', '');
+        const replaceNewLine = new RegExp('/\r\ng');
+        const replaceBracket = new RegExp('/[]g');
+        const definition = defArr[i].definition.replace(replaceNewLine, '\n\n<').replace(replaceBracket, '');
 
         blocks.push({
           type: 'section',

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -67,7 +67,7 @@ export class DefineService {
           text: {
             type: 'mrkdwn',
             text: `> ${this.formatUrbanD(
-              `${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition.replace('\r\n', '  '), false)}`,
+              `${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition.replace('\r\n', '<br/>'), false)}`,
             )}`,
           },
         });

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -63,10 +63,10 @@ export class DefineService {
     for (let i = 0; i < defArr.length; i++) {
       if (defArr[i].word.toLowerCase() === definedWord.toLowerCase()) {
         const definition = defArr[i].definition
-          .replace('\r', '')
-          .replace('\n', '\n\n>')
-          .replace('[', '')
-          .replace(']', '');
+          .replaceAll('\r\n', '\n\n<')
+          .replaceAll('[', '')
+          .replaceAll(']', '');
+
         blocks.push({
           type: 'section',
           text: {

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -67,7 +67,7 @@ export class DefineService {
           text: {
             type: 'mrkdwn',
             text: `> ${this.formatUrbanD(
-              `${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition.replace('\r\n', '<br/>'), false)}`,
+              `${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition.replace('\r\n', '\n>'), false)}`,
             )}`,
           },
         });

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -64,7 +64,7 @@ export class DefineService {
       if (defArr[i].word.toLowerCase() === definedWord.toLowerCase()) {
         const carriageAndNewLine = /(\r\n)/g;
         const replaceBracket = /[\[\]]/g;
-        const definition = defArr[i].definition.replace(carriageAndNewLine, '\n> ').replace(replaceBracket, '');
+        const definition = defArr[i].definition.replace(carriageAndNewLine, '\n\n> ').replace(replaceBracket, '');
 
         blocks.push({
           type: 'section',

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -66,9 +66,7 @@ export class DefineService {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `> ${this.formatUrbanD(
-              `${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition, false).replace('\r\n', '\n')}`,
-            )}`,
+            text: `> ${this.formatUrbanD(`${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition, false)}`)}`,
           },
         });
       }
@@ -84,6 +82,7 @@ export class DefineService {
    * Takes in a definition and removes brackets.
    */
   private formatUrbanD(definition: string): string {
+    console.log(definition);
     let formattedDefinition = '';
     for (const letter of definition) {
       if (letter !== '[' && letter !== ']') {

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -67,7 +67,7 @@ export class DefineService {
           text: {
             type: 'mrkdwn',
             text: `> ${this.formatUrbanD(
-              `${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition.replace('\r\n', '\n>'), false)}`,
+              `${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition.replace('\r\n', '\n\n>'), false)}`,
             )}`,
           },
         });

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -67,7 +67,7 @@ export class DefineService {
         const newLine = /\n/g;
         const definition = defArr[i].definition
           .replace(newLine, '')
-          .replace(carriageReturn, '\n\n')
+          .replace(carriageReturn, '\n\n >')
           .replace(replaceBracket, '');
 
         blocks.push({

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -45,29 +45,26 @@ export class DefineService {
   /**
    * Takes in an array of definitions and breaks them down into a shortened list depending on maxDefs
    */
-  public formatDefs(defArr: Definition[], definedWord: string, maxDefs = 3): { text: string }[] {
+  public formatDefs(defArr: Definition[], definedWord: string, maxDefs = 3): string {
     if (!defArr || defArr.length === 0) {
-      return [{ text: 'Sorry, no definitions found.' }];
+      return 'Sorry, no definitions found.';
     }
 
-    const formattedArr: Attachment[] = [];
+    let definitions = '';
 
     for (let i = 0; i < defArr.length; i++) {
       if (defArr[i].word.toLowerCase() === definedWord.toLowerCase()) {
-        formattedArr.push({
-          text: this.formatUrbanD(
-            `${formattedArr.length + 1}. ${this.capitalizeFirstLetter(defArr[i].definition, false)}`,
-          ),
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          mrkdown_in: ['text'],
-        });
+        definitions += `${this.formatUrbanD(
+          `${i + 1}. ${this.capitalizeFirstLetter(defArr[i].definition, false)}`,
+        )} \n`;
       }
 
-      if (formattedArr.length === maxDefs) {
-        return formattedArr;
+      if (i === maxDefs - 1) {
+        return definitions;
       }
     }
-    return formattedArr.length ? formattedArr : [{ text: 'Sorry, no definitions found.' }];
+
+    return definitions.length ? definitions : 'Sorry, no definitions found.';
   }
   /**
    * Takes in a definition and removes brackets.

--- a/src/services/define/define.service.ts
+++ b/src/services/define/define.service.ts
@@ -1,6 +1,5 @@
 import Axios, { AxiosResponse } from 'axios';
 import { Definition, UrbanDictionaryResponse } from '../../shared/models/define/define-models';
-import { Attachment } from '../../shared/models/slack/slack-models';
 
 export class DefineService {
   public static getInstance(): DefineService {

--- a/src/services/web/web.service.ts
+++ b/src/services/web/web.service.ts
@@ -25,7 +25,7 @@ export class WebService {
   /**
    * Handles deletion of messages.
    */
-  public deleteMessage(channel: string, ts: string, times = 0): void {
+  public deleteMessage(channel: string, ts: string, user: string, times = 0): void {
     if (times > MAX_RETRIES) {
       return;
     }
@@ -38,24 +38,25 @@ export class WebService {
       as_user: true,
     };
 
-    this.web.chat.delete(deleteRequest).catch(e => {
-      if (e.data.error !== 'message_not_found') {
+    this.web.chat
+      .delete(deleteRequest)
+      .then(r => {
+        if (r.error) {
+          console.error(r.error);
+          console.error(deleteRequest);
+          console.log(user);
+        }
+      })
+      .catch(e => {
         console.error(e);
-        console.error('delete request was : ');
-        console.error(deleteRequest);
-        console.error('Unable to delete message. Retrying in 5 seconds...');
-        setTimeout(() => this.deleteMessage(channel, ts, times + 1), 5000);
-      }
-    });
-  }
-
-  public sendDebugMessage(userId: string, text: string) {
-    const options: ChatPostEphemeralArguments = {
-      channel: userId,
-      text,
-      user: userId,
-    };
-    return this.web.chat.postEphemeral(options);
+        if (e.data.error !== 'message_not_found') {
+          console.error(e);
+          console.error('delete request was : ');
+          console.error(deleteRequest);
+          console.error('Unable to delete message. Retrying in 5 seconds...');
+          setTimeout(() => this.deleteMessage(channel, ts, user, times + 1), 5000);
+        }
+      });
   }
 
   /**

--- a/src/services/web/web.service.ts
+++ b/src/services/web/web.service.ts
@@ -6,6 +6,8 @@ import {
   WebClient,
   ChatPostEphemeralArguments,
   ChatUpdateArguments,
+  KnownBlock,
+  Block,
 } from '@slack/web-api';
 
 const MAX_RETRIES = 5;
@@ -59,49 +61,18 @@ export class WebService {
   /**
    * Handles sending messages to the chat.
    */
-  public sendMessage(channel: string, text: string): Promise<WebAPICallResult> {
+  public sendMessage(channel: string, text: string, blocks?: Block[] | KnownBlock[]): Promise<WebAPICallResult> {
     const token: string | undefined = process.env.MUZZLE_BOT_USER_TOKEN;
     const postRequest: ChatPostMessageArguments = {
       token,
       channel,
       text,
     };
-    return this.web.chat
-      .postMessage(postRequest)
-      .then(result => result)
-      .catch(e => {
-        console.error(e);
-        throw new Error(e);
-      });
-  }
 
-  public sendBlockMessage(channel: string, text: string) {
-    const token = process.env.MUZZLE_BOT_USER_TOKEN;
-    const timestamp = Math.floor(new Date().getTime() / 1000);
-    const postRequest: ChatPostMessageArguments = {
-      token,
-      channel,
-      text,
-      blocks: [
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text,
-          },
-        },
-        {
-          type: 'context',
-          elements: [
-            {
-              type: 'mrkdwn',
-              text: `<!date^${timestamp}^Posted {date_num} {time_secs}|Posted at some point today>`,
-              verbatim: false,
-            },
-          ],
-        },
-      ],
-    };
+    if (blocks) {
+      postRequest.blocks = blocks;
+    }
+
     return this.web.chat
       .postMessage(postRequest)
       .then(result => result)

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -204,7 +204,7 @@ export class SuppressorService {
     dbId: number,
     persistenceService: MuzzlePersistenceService | BackFirePersistenceService | CounterPersistenceService,
   ): Promise<void> {
-    await this.webService.deleteMessage(channel, timestamp);
+    await this.webService.deleteMessage(channel, timestamp, userId);
 
     const words = text.split(' ');
 

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -185,10 +185,14 @@ export class SuppressorService {
       charactersSuppressed += words[i].length;
     }
 
-    if (persistenceService) {
-      persistenceService.incrementMessageSuppressions(id);
-      persistenceService.incrementCharacterSuppressions(id, charactersSuppressed);
-      persistenceService.incrementWordSuppressions(id, wordsSuppressed);
+    try {
+      if (persistenceService) {
+        persistenceService.incrementMessageSuppressions(id);
+        persistenceService.incrementCharacterSuppressions(id, charactersSuppressed);
+        persistenceService.incrementWordSuppressions(id, wordsSuppressed);
+      }
+    } catch (e) {
+      console.error(e);
     }
   }
 

--- a/src/shared/services/suppressor.service.ts
+++ b/src/shared/services/suppressor.service.ts
@@ -214,7 +214,9 @@ export class SuppressorService {
     });
 
     if (suppressedMessage === null) {
-      this.sendFallbackSuppressedMessage(text, dbId, persistenceService);
+      await this.webService.deleteMessage(channel, timestamp);
+      const message = this.sendFallbackSuppressedMessage(text, dbId, persistenceService);
+      await this.webService.sendMessage(channel, `<@${userId}> says "${message}"`);
     } else {
       await this.logTranslateSuppression(text, dbId, persistenceService);
       await this.webService.deleteMessage(channel, timestamp);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     "target": "ES5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    "lib": ["ES2019"] /* Specify library files to be included in the compilation. */,
+    "lib": ["es2021"] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     "target": "ES5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    "lib": ["es2021"] /* Specify library files to be included in the compilation. */,
+    "lib": ["esnext"] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     "target": "ES5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    "lib": ["esnext"] /* Specify library files to be included in the compilation. */,
+    "lib": ["ES2019"] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
- Added tagging to the definition and also converted to use blocks
- Removed unnecessary import
- Fixed formatting
- Removed bold for header
- Added blocks log
- Removed /r
- Added log for definition
- Added replace for /r/n
- Added two empty spaces to force line break where necessary
- Changed double space to br
- Formatting
- Added double new line
- Removed format urban D
- used replaceAll instead
- updated to latest ts-node
- Converted to using esnext
- Replaced with regexp
- Changed regexp
- More regex tweaks
- Added proper quote character
- Removed first quote
- Added list instead of quote
- Formatting changes
- More changes
- Added comment for any new line that is followed by char
- More regex fun
- Added double new line
- More quotes
- added another divider
- Added noDefFound
- Added quote
- Added removal of new line new lne
- Added sparkles
- Added italics
- Removed italics
- Added italics back
- Removed capitalizing all first letters in definition
- Added verify=False for all requests calls
- Updated fallback
- Added fix for numbering scheme in define
- Added deleteMessage call to event.controller
- Added deleteMessage call to event.controller for backfire
- Added try catch to logTranslate suppression
- Added patch to avoid JP from being able to translate gigantic word documents
- Added shouldFallback and short circuiting for google translate
- Added userId to deleteMessage requests
- Removed first divider on definition blocks
