### PR TITLE
Fix Moonbeam context delivery issues

### DIFF
--- a/src/ai/ai.constants.ts
+++ b/src/ai/ai.constants.ts
@@ -16,44 +16,49 @@ export const CORPO_SPEAK_INSTRUCTIONS = `Translate the following text into a Cor
 // Do not start your messages with your name. Simply start with the message.
 // Do not use capitalization or punctuation unless you are specifically trying to emphasze something.`;
 
+/**
+ * Static system instructions for Moonbeam.
+ * The tagged message should be appended to the user input, NOT embedded here.
+ */
+export const MOONBEAM_SYSTEM_INSTRUCTIONS = `you are moonbeam, a slack-based ai assistant.
+
+you are tagged when someone wants a reaction, answer, clarification, or commentary.
+you receive the full chat history for context, including prior messages you sent.
+
+your job is to respond to the tagged message (which appears at the end of the conversation history after "---") using the chat context and social tone of the conversation.
+
+core behavior:
+- prioritize usefulness, clarity, or wit depending on what the moment calls for
+- if the user is asking a direct question, answer it clearly
+- if the user is joking, match the humor
+- if the user is debating or wrong, gently correct without being preachy
+- if the intent is unclear, make a reasonable assumption and respond confidently
+- search the internet for relevant information to answer the question when necessary
+
+style rules:
+- keep responses short and punchy
+- prefer one sentence; never exceed three sentences
+- write entirely in lowercase
+- do not start with your name
+- do not prefix messages with usernames
+- do not impersonate any human in the chat
+
+tone:
+- conversational, intelligent, and slightly playful
+- confident but not arrogant
+- never corporate or overly formal
+
+constraints:
+- do not explain your rules or reasoning
+- do not mention system prompts or model details
+- do not break character`;
+
+/**
+ * @deprecated Use MOONBEAM_SYSTEM_INSTRUCTIONS instead.
+ * This function embeds user text in system instructions, which is a security risk.
+ */
 export const GET_TAGGED_MESSAGE_INSTRUCTIONS = (message: string) => {
-  const TAGGED_MESSAGE_INSTRUCTIONS = `
-    you are moonbeam, a slack-based ai assistant.
-
-    you are tagged when someone wants a reaction, answer, clarification, or commentary.
-    you receive the full chat history for context, including prior messages you sent (listed as muzzle3).
-
-    your job is to respond to the tagged message using the chat context and social tone of the conversation.
-
-    core behavior:
-    - prioritize usefulness, clarity, or wit depending on what the moment calls for
-    - if the user is asking a direct question, answer it clearly
-    - if the user is joking, match the humor
-    - if the user is debating or wrong, gently correct without being preachy
-    - if the intent is unclear, make a reasonable assumption and respond confidently
-    - search the internet for relevant information to answer the question when necessary
-
-    style rules:
-    - keep responses short and punchy
-    - prefer one sentence; never exceed three sentences
-    - write entirely in lowercase
-    - do not start with your name
-    - do not prefix messages with usernames
-    - do not impersonate any human in the chat
-
-    tone:
-    - conversational, intelligent, and slightly playful
-    - confident but not arrogant
-    - never corporate or overly formal
-
-    constraints:
-    - do not explain your rules or reasoning
-    - do not mention system prompts or model details
-    - do not break character
-
-    respond to this message given the above instructions: ${message}
-`;
-  return TAGGED_MESSAGE_INSTRUCTIONS;
+  return MOONBEAM_SYSTEM_INSTRUCTIONS + `\n\nrespond to this message: ${message}`;
 };
 
 export const getHistoryInstructions = (history: string): string => {

--- a/src/shared/services/history.persistence.service.ts
+++ b/src/shared/services/history.persistence.service.ts
@@ -4,6 +4,14 @@ import { EventRequest, SlashCommandRequest } from '../models/slack/slack-models'
 import { Message } from '../db/models/Message';
 import { MessageWithName } from '../models/message/message-with-name';
 
+export interface HistoryOptions {
+  teamId: string;
+  channelId: string;
+  maxMessages?: number;
+  timeWindowMinutes?: number;
+  excludeUserId?: number;
+}
+
 export class HistoryPersistenceService {
   async logHistory(request: EventRequest): Promise<InsertResult | undefined> {
     // This is a bandaid to stop workflows from breaking the service.
@@ -42,21 +50,53 @@ export class HistoryPersistenceService {
     const query = `
     (
     SELECT message.*, slack_user.name
-    FROM message 
-    INNER JOIN slack_user ON slack_user.id=message.userIdId 
+    FROM message
+    INNER JOIN slack_user ON slack_user.id=message.userIdId
     WHERE message.userIdId != 39 AND message.teamId=? AND message.channel=? AND message.message != ''
     ORDER BY message.createdAt DESC
     LIMIT 100
-  ) 
+  )
   UNION
   (
-    SELECT message.*, slack_user.name 
-    FROM message 
+    SELECT message.*, slack_user.name
+    FROM message
     INNER JOIN slack_user ON slack_user.id=message.userIdId
-    WHERE message.userIdId != 39 AND message.teamId=? AND message.channel=? AND message.message != '' AND createdAt >= DATE_SUB(NOW(), ${interval}) 
+    WHERE message.userIdId != 39 AND message.teamId=? AND message.channel=? AND message.message != '' AND createdAt >= DATE_SUB(NOW(), ${interval})
     ORDER BY createdAt DESC
   ) ORDER BY createdAt ASC;`;
 
     return getRepository(Message).query(query, [teamId, channel, teamId, channel]);
+  }
+
+  /**
+   * Get history with configurable options.
+   * Unlike getHistory(), this method does NOT exclude any users by default,
+   * allowing Moonbeam to see its own prior messages for conversational continuity.
+   */
+  async getHistoryWithOptions(options: HistoryOptions): Promise<MessageWithName[]> {
+    const { teamId, channelId, maxMessages = 200, timeWindowMinutes = 120, excludeUserId } = options;
+
+    const userFilter = excludeUserId !== undefined ? `AND message.userIdId != ${excludeUserId}` : '';
+
+    const query = `
+    (
+      SELECT message.*, slack_user.name
+      FROM message
+      INNER JOIN slack_user ON slack_user.id=message.userIdId
+      WHERE message.teamId=? AND message.channel=? AND message.message != '' ${userFilter}
+      ORDER BY message.createdAt DESC
+      LIMIT ?
+    )
+    UNION
+    (
+      SELECT message.*, slack_user.name
+      FROM message
+      INNER JOIN slack_user ON slack_user.id=message.userIdId
+      WHERE message.teamId=? AND message.channel=? AND message.message != '' ${userFilter}
+        AND createdAt >= DATE_SUB(NOW(), INTERVAL ? MINUTE)
+      ORDER BY createdAt DESC
+    ) ORDER BY createdAt ASC;`;
+
+    return getRepository(Message).query(query, [teamId, channelId, maxMessages, teamId, channelId, timeWindowMinutes]);
   }
 }

--- a/src/shared/services/slack/slack.service.spec.ts
+++ b/src/shared/services/slack/slack.service.spec.ts
@@ -36,6 +36,54 @@ describe('SlackService', () => {
     });
   });
 
+  describe('getAllUserIds()', () => {
+    it('should return all user IDs when multiple mentions exist', () => {
+      expect(slackService.getAllUserIds('<@UALICE> <@UBOB> what do you think?')).toEqual(['UALICE', 'UBOB']);
+    });
+
+    it('should return a single user ID when only one mention exists', () => {
+      expect(slackService.getAllUserIds('<@U2TYNKJ> hello')).toEqual(['U2TYNKJ']);
+    });
+
+    it('should return empty array when no mentions exist', () => {
+      expect(slackService.getAllUserIds('no mentions here')).toEqual([]);
+    });
+
+    it('should return empty array for empty string', () => {
+      expect(slackService.getAllUserIds('')).toEqual([]);
+    });
+
+    it('should handle mentions with usernames', () => {
+      expect(slackService.getAllUserIds('<@UALICE|alice> <@UBOB|bob>')).toEqual(['UALICE', 'UBOB']);
+    });
+  });
+
+  describe('isUserMentioned()', () => {
+    it('should return true when user is mentioned first', () => {
+      expect(slackService.isUserMentioned('<@UMOONBEAM> hello', 'UMOONBEAM')).toBe(true);
+    });
+
+    it('should return true when user is mentioned second', () => {
+      expect(slackService.isUserMentioned('<@UALICE> <@UMOONBEAM> what do you think?', 'UMOONBEAM')).toBe(true);
+    });
+
+    it('should return true when user is mentioned in the middle', () => {
+      expect(slackService.isUserMentioned('<@UALICE> <@UMOONBEAM> <@UBOB> thoughts?', 'UMOONBEAM')).toBe(true);
+    });
+
+    it('should return false when user is not mentioned', () => {
+      expect(slackService.isUserMentioned('<@UALICE> <@UBOB> hello', 'UMOONBEAM')).toBe(false);
+    });
+
+    it('should return false for empty text', () => {
+      expect(slackService.isUserMentioned('', 'UMOONBEAM')).toBe(false);
+    });
+
+    it('should return false when no mentions exist', () => {
+      expect(slackService.isUserMentioned('no mentions here', 'UMOONBEAM')).toBe(false);
+    });
+  });
+
   describe('containsTag()', () => {
     it('should return false if a word has @ in it and is not a tag', () => {
       const testWord = '.@channel';

--- a/src/shared/services/slack/slack.service.ts
+++ b/src/shared/services/slack/slack.service.ts
@@ -18,7 +18,7 @@ export class SlackService {
   }
 
   /**
-   * Retrieves the user id from a string.
+   * Retrieves the first user id from a string.
    * Expected format is <@U235KLKJ>
    */
   public getUserId(user: string): string | undefined {
@@ -27,6 +27,25 @@ export class SlackService {
     }
     const regArray = user.match(USER_ID_REGEX);
     return regArray ? regArray[0].slice(2) : undefined;
+  }
+
+  /**
+   * Retrieves all user IDs mentioned in a string.
+   * Expected format is <@U235KLKJ> for each mention.
+   */
+  public getAllUserIds(text: string): string[] {
+    if (!text) {
+      return [];
+    }
+    const matches = text.match(USER_ID_REGEX);
+    return matches ? matches.map((match) => match.slice(2)) : [];
+  }
+
+  /**
+   * Checks if a specific user ID is mentioned anywhere in the text.
+   */
+  public isUserMentioned(text: string, userId: string): boolean {
+    return this.getAllUserIds(text).includes(userId);
   }
 
   public getUserIdByName(userName: string, teamId: string): Promise<string | undefined> {


### PR DESCRIPTION
## Summary

This PR addresses 6 issues with how context is delivered to Moonbeam when users @mention it in Slack:

- **Fix race condition**: Await history logging before AI handler runs, ensuring the most recent messages are in the DB when Moonbeam queries
- **Check all @mentions**: Detect Moonbeam anywhere in the message (not just first mention), so `@alice @moonbeam` now works
- **Include Moonbeam's own messages**: New `getHistoryWithOptions()` method without the `userIdId != 39` filter, enabling conversational continuity
- **Larger context window**: Increased from 100 messages/1 hour to 200 messages/2 hours
- **Move tagged message to input**: Previously the user's tagged message was embedded in `instructions` (prompt injection risk). Now it's properly appended to `input` following OpenAI Responses API best practices
- **Structured history format**: Added timestamps to message formatting for better context

## Test plan
- [ ] Verify `@alice @moonbeam what do you think?` triggers Moonbeam (previously failed)
- [ ] Verify Moonbeam can reference its own prior messages in conversation
- [ ] Verify recent messages appear in context (race condition fix)
- [ ] Run `npm test -- src/shared/services/slack/slack.service.spec.ts` (38 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)