### PR TITLE
feat: Add private channel support for Moonbeam

### DIFF
--- a/src/shared/services/slack/slack.service.ts
+++ b/src/shared/services/slack/slack.service.ts
@@ -154,6 +154,9 @@ export class SlackService {
       this.getAllUsers().catch((e) => this.logger.error('Error handling team join event:', e));
     } else if (request.event.type === 'channel_created') {
       this.getAndSaveAllChannels();
+    } else if (request.event.type === 'member_joined_channel') {
+      // Refresh channels when bot joins a new channel (including private)
+      this.getAndSaveAllChannels();
     }
   }
 }

--- a/src/shared/services/web/web.service.ts
+++ b/src/shared/services/web/web.service.ts
@@ -115,7 +115,10 @@ export class WebService {
   }
 
   public getAllChannels(): Promise<ConversationsListResponse> {
-    return this.web.conversations.list();
+    return this.web.conversations.list({
+      types: 'public_channel,private_channel',
+      exclude_archived: true,
+    });
   }
 
   public uploadFile(channel: string, content: string, title: string, userId: string): void {


### PR DESCRIPTION
- Update conversations.list() to include private_channel type
- Add member_joined_channel event handler to refresh channel list
- Enables Moonbeam to work in private channels after being invited