### PR TITLE
Fixed bad permissions scheme in dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,13 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Enforce 80% coverage
         run: npm run test:coverage
+
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build -f packages/backend/Dockerfile -t mocker-backend:ci .

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -14,7 +14,8 @@ COPY packages/backend/src ./packages/backend/src
 RUN npm ci \
 	&& npm run build:prod -w @mocker/backend \
 	&& npm prune --omit=dev \
-	&& mkdir -p /usr/src/app/images
+	&& mkdir -p /usr/src/app/images \
+	&& chmod 700 /usr/src/app/images
 
 FROM gcr.io/distroless/nodejs20-debian12:nonroot AS release
 ENV NODE_ENV=production \

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -25,9 +25,7 @@ WORKDIR /usr/src/app
 # Copy backend build artifacts and writable path from build stage.
 COPY --from=build --chown=65532:65532 /usr/src/app/packages/backend/dist ./dist
 COPY --from=build --chown=65532:65532 /usr/src/app/node_modules ./node_modules
-COPY --from=build --chown=65532:65532 /usr/src/app/images ./images
-
-RUN chmod 700 /usr/src/app/images
+COPY --from=build --chown=65532:65532 --chmod=700 /usr/src/app/images ./images
 
 EXPOSE 80
 

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -14,8 +14,7 @@ COPY packages/backend/src ./packages/backend/src
 RUN npm ci \
 	&& npm run build:prod -w @mocker/backend \
 	&& npm prune --omit=dev \
-	&& mkdir -p /usr/src/app/images \
-	&& chmod 700 /usr/src/app/images
+	&& mkdir -p /usr/src/app/images
 
 FROM gcr.io/distroless/nodejs20-debian12:nonroot AS release
 ENV NODE_ENV=production \
@@ -27,6 +26,8 @@ WORKDIR /usr/src/app
 COPY --from=build --chown=65532:65532 /usr/src/app/packages/backend/dist ./dist
 COPY --from=build --chown=65532:65532 /usr/src/app/node_modules ./node_modules
 COPY --from=build --chown=65532:65532 /usr/src/app/images ./images
+
+RUN chmod 700 /usr/src/app/images
 
 EXPOSE 80
 


### PR DESCRIPTION
This pull request makes a minor update to the Docker build process for the backend package, specifically improving the security of the images directory.

* Dockerfile improvement:
  * In `packages/backend/Dockerfile`, after creating the `/usr/src/app/images` directory during the build, the directory's permissions are set to `700` to restrict access to the owner only.