### PR TITLE
feat: stream @Moonbeam responses with shimmer UX and thread awareness

### DIFF
--- a/docs/superpowers/plans/2026-03-27-streaming-responses.md
+++ b/docs/superpowers/plans/2026-03-27-streaming-responses.md
@@ -1,0 +1,654 @@
+# Streaming Responses & Thread Awareness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add thread awareness and Slack native streaming to @Moonbeam responses so users see a shimmer loading indicator and word-by-word text as the AI generates.
+
+**Architecture:** Add `thread_ts` to the Event model so the bot knows when a message is in a thread. Pass the message `ts` (or `thread_ts` if already in a thread) to `participate()`, which uses Slack's `chatStream()` API to stream OpenAI's response in real time. The response appears as a threaded reply under the user's message. Falls back to `sendMessage()` if streaming fails.
+
+**Tech Stack:** `@slack/web-api ^7.15.0` (ChatStreamer, chatStream), `openai ^4.103.0` (streaming responses), TypeScript, Jest
+
+---
+
+## File Structure
+
+| File                                                           | Action | Responsibility                                     |
+| -------------------------------------------------------------- | ------ | -------------------------------------------------- |
+| `packages/backend/src/shared/models/slack/slack-models.ts`     | Modify | Add `thread_ts` to `Event` interface               |
+| `packages/backend/src/shared/services/web/web.service.ts`      | Modify | Add `startStream()` method                         |
+| `packages/backend/src/ai/ai.service.ts`                        | Modify | Thread-aware `handle()`, streaming `participate()` |
+| `packages/backend/src/test/mocks/slack-web-api.mock.ts`        | Modify | Add `chatStream` mock                              |
+| `packages/backend/src/shared/services/web/web.service.spec.ts` | Modify | Add `startStream()` tests                          |
+| `packages/backend/src/ai/ai.service.spec.ts`                   | Modify | Update `handle()` and `participate()` tests        |
+
+---
+
+### Task 1: Add `thread_ts` to Event interface
+
+**Files:**
+
+- Modify: `packages/backend/src/shared/models/slack/slack-models.ts:38-62`
+
+- [ ] **Step 1: Add `thread_ts` to the `Event` interface**
+
+In `packages/backend/src/shared/models/slack/slack-models.ts`, add `thread_ts` as an optional field to the `Event` interface, after the existing `ts` field on line 45:
+
+```typescript
+export interface Event {
+  client_msg_id: string;
+  type: string;
+  subtype: string;
+  text: string;
+  user: string;
+  username: string;
+  ts: string;
+  thread_ts?: string;
+  channel: string;
+  event_ts: string;
+  channel_type: string;
+  authed_users: string[];
+  attachments: Event[];
+  pretext: string;
+  callback_id: string;
+  item_user: string;
+  reaction: string;
+  item: EventItem; // Needs work, not optional either.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  blocks: Record<any, any>[]; // same same
+  bot_id: string;
+  bot_profile: {
+    name: string;
+  };
+}
+```
+
+- [ ] **Step 2: Verify the build passes**
+
+Run: `npm run build:backend`
+Expected: Clean compilation with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/backend/src/shared/models/slack/slack-models.ts
+git commit -m "feat: add thread_ts to Event interface for thread awareness"
+```
+
+---
+
+### Task 2: Add `chatStream` to the Slack mock and `startStream()` to WebService
+
+**Files:**
+
+- Modify: `packages/backend/src/test/mocks/slack-web-api.mock.ts`
+- Modify: `packages/backend/src/shared/services/web/web.service.spec.ts`
+- Modify: `packages/backend/src/shared/services/web/web.service.ts`
+
+- [ ] **Step 1: Add `chatStream` to the Slack WebClient mock**
+
+In `packages/backend/src/test/mocks/slack-web-api.mock.ts`, add a `chatStream` method that returns a mock `ChatStreamer` object with `append` and `stop` methods:
+
+```typescript
+type SlackResult = Record<string, unknown> & { ok: boolean };
+
+const okResult = (): SlackResult => ({ ok: true });
+
+export class WebClient {
+  chat = {
+    delete: jest.fn().mockResolvedValue(okResult()),
+    postEphemeral: jest.fn().mockResolvedValue(okResult()),
+    postMessage: jest.fn().mockResolvedValue(okResult()),
+    update: jest.fn().mockResolvedValue(okResult()),
+  };
+
+  users = {
+    list: jest.fn().mockResolvedValue({ ok: true, members: [] }),
+  };
+
+  conversations = {
+    list: jest.fn().mockResolvedValue({ ok: true, channels: [] }),
+  };
+
+  files = {
+    upload: jest.fn().mockResolvedValue(okResult()),
+  };
+
+  chatStream = jest.fn().mockReturnValue({
+    append: jest.fn().mockResolvedValue(null),
+    stop: jest.fn().mockResolvedValue(okResult()),
+  });
+
+  constructor(_token?: string) {
+    void _token;
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing test for `startStream()`**
+
+Add a new `describe` block to `packages/backend/src/shared/services/web/web.service.spec.ts`:
+
+```typescript
+describe('startStream', () => {
+  it('calls chatStream with channel, thread_ts, and token', () => {
+    const streamer = webService.startStream('C1', '1700000001.123456');
+
+    expect(mockWebClient.chatStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'C1',
+        thread_ts: '1700000001.123456',
+      }),
+    );
+    expect(streamer).toBeDefined();
+    expect(streamer.append).toBeDefined();
+    expect(streamer.stop).toBeDefined();
+  });
+});
+```
+
+Also update the `MockWebClient` type at the top of the test file to include `chatStream`:
+
+```typescript
+type MockWebClient = {
+  chat: {
+    postMessage: jest.Mock;
+    delete: jest.Mock;
+    postEphemeral: jest.Mock;
+    update: jest.Mock;
+  };
+  users: { list: jest.Mock };
+  conversations: { list: jest.Mock };
+  files: { upload: jest.Mock };
+  chatStream: jest.Mock;
+};
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npm run test:backend -- --testPathPattern="web.service.spec" --verbose`
+Expected: FAIL — `webService.startStream is not a function`
+
+- [ ] **Step 4: Implement `startStream()` in WebService**
+
+In `packages/backend/src/shared/services/web/web.service.ts`, add the import for `ChatStreamer` and the new method:
+
+Add to the imports at the top:
+
+```typescript
+import type {
+  ChatDeleteArguments,
+  ChatPostMessageArguments,
+  FilesUploadArguments,
+  WebAPICallResult,
+  ChatPostEphemeralArguments,
+  ChatUpdateArguments,
+  KnownBlock,
+  Block,
+  ConversationsListResponse,
+  UsersListResponse,
+} from '@slack/web-api';
+import { WebClient } from '@slack/web-api';
+import type { ChatStreamer } from '@slack/web-api/dist/chat-stream';
+import { logError } from '../../logger/error-logging';
+import { logger } from '../../logger/logger';
+```
+
+Add the method to the `WebService` class, after `editMessage()`:
+
+```typescript
+  public startStream(channel: string, threadTs: string): ChatStreamer {
+    return this.web.chatStream({
+      channel,
+      thread_ts: threadTs,
+      token: process.env.MUZZLE_BOT_USER_TOKEN,
+    });
+  }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npm run test:backend -- --testPathPattern="web.service.spec" --verbose`
+Expected: All tests PASS, including the new `startStream` test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/backend/src/test/mocks/slack-web-api.mock.ts packages/backend/src/shared/services/web/web.service.ts packages/backend/src/shared/services/web/web.service.spec.ts
+git commit -m "feat: add startStream() to WebService for Slack chat streaming"
+```
+
+---
+
+### Task 3: Update `handle()` to pass thread context
+
+**Files:**
+
+- Modify: `packages/backend/src/ai/ai.service.ts:780-790`
+- Modify: `packages/backend/src/ai/ai.service.spec.ts` (handle tests)
+
+- [ ] **Step 1: Write the failing test for thread_ts passthrough**
+
+In `packages/backend/src/ai/ai.service.spec.ts`, update the existing `handle` describe block. Add a new test and update the existing test to verify `threadTs` is passed:
+
+```typescript
+it('passes event.ts as threadTs when not in a thread', async () => {
+  (aiService.slackService.containsTag as jest.Mock).mockReturnValue(true);
+  (aiService.slackService.isUserMentioned as jest.Mock).mockReturnValue(true);
+  (aiService.muzzlePersistenceService.isUserMuzzled as jest.Mock).mockResolvedValue(false);
+  const participateSpy = jest.spyOn(aiService, 'participate').mockResolvedValue();
+
+  await aiService.handle({
+    team_id: 'T1',
+    event: {
+      user: 'U1',
+      channel: 'C1',
+      text: `<@${MOONBEAM_SLACK_ID}> hello`,
+      ts: '1700000001.123456',
+    },
+  } as never);
+
+  expect(participateSpy).toHaveBeenCalledWith('T1', 'C1', `<@${MOONBEAM_SLACK_ID}> hello`, 'U1', '1700000001.123456');
+});
+
+it('passes event.thread_ts as threadTs when in a thread', async () => {
+  (aiService.slackService.containsTag as jest.Mock).mockReturnValue(true);
+  (aiService.slackService.isUserMentioned as jest.Mock).mockReturnValue(true);
+  (aiService.muzzlePersistenceService.isUserMuzzled as jest.Mock).mockResolvedValue(false);
+  const participateSpy = jest.spyOn(aiService, 'participate').mockResolvedValue();
+
+  await aiService.handle({
+    team_id: 'T1',
+    event: {
+      user: 'U1',
+      channel: 'C1',
+      text: `<@${MOONBEAM_SLACK_ID}> hello`,
+      ts: '1700000002.654321',
+      thread_ts: '1700000001.123456',
+    },
+  } as never);
+
+  expect(participateSpy).toHaveBeenCalledWith('T1', 'C1', `<@${MOONBEAM_SLACK_ID}> hello`, 'U1', '1700000001.123456');
+});
+```
+
+Also update the existing `'participates when Moonbeam is tagged and user is not muzzled'` test to include `ts` in the event and expect the 5th argument:
+
+```typescript
+it('participates when Moonbeam is tagged and user is not muzzled', async () => {
+  (aiService.slackService.containsTag as jest.Mock).mockReturnValue(true);
+  (aiService.slackService.isUserMentioned as jest.Mock).mockReturnValue(true);
+  (aiService.muzzlePersistenceService.isUserMuzzled as jest.Mock).mockResolvedValue(false);
+  const participateSpy = jest.spyOn(aiService, 'participate').mockResolvedValue();
+
+  await aiService.handle({
+    team_id: 'T1',
+    event: {
+      user: 'U1',
+      channel: 'C1',
+      text: `<@${MOONBEAM_SLACK_ID}> hello`,
+      ts: '1700000001.000000',
+    },
+  } as never);
+
+  expect(participateSpy).toHaveBeenCalledWith('T1', 'C1', `<@${MOONBEAM_SLACK_ID}> hello`, 'U1', '1700000001.000000');
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run test:backend -- --testPathPattern="ai.service.spec" --verbose`
+Expected: FAIL — `participate` called with 4 args, expected 5.
+
+- [ ] **Step 3: Update `handle()` to pass threadTs**
+
+In `packages/backend/src/ai/ai.service.ts`, update the `handle()` method (lines 780-790):
+
+```typescript
+  async handle(request: EventRequest): Promise<void> {
+    const isUserMuzzled = await this.muzzlePersistenceService.isUserMuzzled(request.event.user, request.team_id);
+    if (this.slackService.containsTag(request.event.text) && !isUserMuzzled) {
+      // Check if Moonbeam is mentioned ANYWHERE in the message (not just first mention)
+      const isMoonbeamTagged = this.slackService.isUserMentioned(request.event.text, MOONBEAM_SLACK_ID);
+      const isPosterMoonbeam = request.event.user === MOONBEAM_SLACK_ID;
+      if (isMoonbeamTagged && !isPosterMoonbeam) {
+        const threadTs = request.event.thread_ts ?? request.event.ts;
+        void this.participate(
+          request.team_id,
+          request.event.channel,
+          request.event.text,
+          request.event.user,
+          threadTs,
+        );
+      }
+    }
+  }
+```
+
+- [ ] **Step 4: Update `participate()` signature to accept threadTs**
+
+Change the signature on line 441 from:
+
+```typescript
+public async participate(teamId: string, channelId: string, taggedMessage: string, userId?: string): Promise<void> {
+```
+
+to:
+
+```typescript
+public async participate(teamId: string, channelId: string, taggedMessage: string, userId?: string, threadTs?: string): Promise<void> {
+```
+
+Do NOT change the body yet — just the signature. The streaming implementation is Task 4.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npm run test:backend -- --testPathPattern="ai.service.spec" --verbose`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/backend/src/ai/ai.service.ts packages/backend/src/ai/ai.service.spec.ts
+git commit -m "feat: pass thread context from handle() to participate()"
+```
+
+---
+
+### Task 4: Refactor `participate()` to use streaming
+
+**Files:**
+
+- Modify: `packages/backend/src/ai/ai.service.ts:441-499`
+- Modify: `packages/backend/src/ai/ai.service.spec.ts`
+
+- [ ] **Step 1: Write the failing test for streaming participate**
+
+In `packages/backend/src/ai/ai.service.spec.ts`, first update `buildAiService()` to add `startStream` to the mock webService:
+
+```typescript
+ai.webService = {
+  sendMessage: jest.fn().mockResolvedValue({ ok: true }),
+  startStream: jest.fn().mockReturnValue({
+    append: jest.fn().mockResolvedValue(null),
+    stop: jest.fn().mockResolvedValue({ ok: true }),
+  }),
+} as unknown as AIService['webService'];
+```
+
+Then add new tests in the `describe('handle', ...)` block or create a new `describe('participate', ...)` block:
+
+```typescript
+describe('participate', () => {
+  it('streams response to Slack when threadTs is provided', async () => {
+    const mockAppend = jest.fn().mockResolvedValue(null);
+    const mockStop = jest.fn().mockResolvedValue({ ok: true });
+    (aiService.webService.startStream as jest.Mock).mockReturnValue({
+      append: mockAppend,
+      stop: mockStop,
+    });
+
+    const mockStream = {
+      async *[Symbol.asyncIterator]() {
+        yield { type: 'response.output_text.delta', delta: 'Hello ' };
+        yield { type: 'response.output_text.delta', delta: 'world!' };
+      },
+    };
+    (aiService.openAi.responses.create as jest.Mock).mockResolvedValue(mockStream);
+
+    await aiService.participate('T1', 'C1', 'hey @Moonbeam', 'U1', '1700000001.123456');
+
+    expect(aiService.webService.startStream).toHaveBeenCalledWith('C1', '1700000001.123456');
+    expect(mockAppend).toHaveBeenCalledWith({ markdown_text: 'Hello ' });
+    expect(mockAppend).toHaveBeenCalledWith({ markdown_text: 'world!' });
+    expect(mockStop).toHaveBeenCalled();
+  });
+
+  it('falls back to sendMessage when threadTs is not provided', async () => {
+    (aiService.openAi.responses.create as jest.Mock).mockResolvedValue({
+      output: [{ type: 'message', content: [{ type: 'output_text', text: 'Response text' }] }],
+    });
+
+    await aiService.participate('T1', 'C1', 'hey @Moonbeam', 'U1');
+
+    expect(aiService.webService.startStream).not.toHaveBeenCalled();
+    expect(aiService.webService.sendMessage).toHaveBeenCalledWith('C1', 'Response text', [
+      { type: 'markdown', text: 'Response text' },
+    ]);
+  });
+
+  it('falls back to sendMessage when streaming throws', async () => {
+    (aiService.webService.startStream as jest.Mock).mockImplementation(() => {
+      throw new Error('streaming not available');
+    });
+    (aiService.openAi.responses.create as jest.Mock).mockResolvedValue({
+      output: [{ type: 'message', content: [{ type: 'output_text', text: 'Fallback text' }] }],
+    });
+
+    await aiService.participate('T1', 'C1', 'hey @Moonbeam', 'U1', '1700000001.123456');
+
+    expect(aiService.webService.sendMessage).toHaveBeenCalledWith('C1', 'Fallback text', [
+      { type: 'markdown', text: 'Fallback text' },
+    ]);
+  });
+
+  it('stops stream cleanly on OpenAI error', async () => {
+    const mockAppend = jest.fn().mockResolvedValue(null);
+    const mockStop = jest.fn().mockResolvedValue({ ok: true });
+    (aiService.webService.startStream as jest.Mock).mockReturnValue({
+      append: mockAppend,
+      stop: mockStop,
+    });
+
+    const mockStream = {
+      async *[Symbol.asyncIterator]() {
+        yield { type: 'response.output_text.delta', delta: 'partial' };
+        throw new Error('OpenAI stream error');
+      },
+    };
+    (aiService.openAi.responses.create as jest.Mock).mockResolvedValue(mockStream);
+
+    await expect(aiService.participate('T1', 'C1', 'hey @Moonbeam', 'U1', '1700000001.123456')).rejects.toThrow(
+      'OpenAI stream error',
+    );
+
+    expect(mockStop).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run test:backend -- --testPathPattern="ai.service.spec" --verbose`
+Expected: FAIL — streaming logic not yet implemented.
+
+- [ ] **Step 3: Implement streaming in `participate()`**
+
+Replace the `participate()` method body in `packages/backend/src/ai/ai.service.ts` (lines 441-499) with:
+
+```typescript
+  public async participate(
+    teamId: string,
+    channelId: string,
+    taggedMessage: string,
+    userId?: string,
+    threadTs?: string,
+  ): Promise<void> {
+    await this.redis.setParticipationInFlight(channelId, teamId);
+
+    try {
+      const historyMessages = await this.historyService.getHistoryWithOptions({
+        teamId,
+        channelId,
+        maxMessages: 200,
+        timeWindowMinutes: 120,
+      });
+
+      const history = this.formatHistory(historyMessages);
+
+      const customPrompt = userId ? await this.slackPersistenceService.getCustomPrompt(userId, teamId) : null;
+      const normalizedCustomPrompt = customPrompt?.trim() || null;
+
+      const participantSlackIds = this.extractParticipantSlackIds(historyMessages, {
+        excludeSlackIds: [MOONBEAM_SLACK_ID],
+      });
+      const memoryContext = await this.fetchMemoryContext(participantSlackIds, teamId, history, historyMessages);
+      const baseInstructions = normalizedCustomPrompt ?? MOONBEAM_SYSTEM_INSTRUCTIONS;
+      const systemInstructions = this.appendMemoryContext(baseInstructions, memoryContext);
+
+      const input = `${history}\n\n---\n[Tagged message to respond to]:\n${taggedMessage}`;
+
+      if (threadTs) {
+        await this.participateWithStreaming(channelId, teamId, systemInstructions, input, threadTs);
+      } else {
+        await this.participateWithMessage(channelId, teamId, systemInstructions, input);
+      }
+
+      await this.redis.setHasParticipated(teamId, channelId);
+    } catch (e) {
+      logError(this.aiServiceLogger, 'Failed to generate AI participation response', e, {
+        teamId,
+        channelId,
+        taggedMessage,
+      });
+      throw e;
+    } finally {
+      void this.redis.removeParticipationInFlight(channelId, teamId);
+    }
+  }
+
+  private async participateWithStreaming(
+    channelId: string,
+    teamId: string,
+    instructions: string,
+    input: string,
+    threadTs: string,
+  ): Promise<void> {
+    let streamer;
+    try {
+      streamer = this.webService.startStream(channelId, threadTs);
+    } catch (e) {
+      this.aiServiceLogger.warn('Failed to start Slack stream, falling back to sendMessage', e);
+      return this.participateWithMessage(channelId, teamId, instructions, input);
+    }
+
+    try {
+      const stream = await this.openAi.responses.create({
+        model: GPT_MODEL,
+        tools: [{ type: 'web_search_preview' }],
+        instructions,
+        input,
+        stream: true,
+        user: `participation-${channelId}-${teamId}-DaBros2016`,
+      });
+
+      for await (const event of stream) {
+        if (event.type === 'response.output_text.delta') {
+          await streamer.append({ markdown_text: event.delta });
+        }
+      }
+
+      await streamer.stop();
+    } catch (e) {
+      await streamer.stop().catch((stopErr: unknown) => {
+        this.aiServiceLogger.warn('Failed to stop stream after error', stopErr);
+      });
+      throw e;
+    }
+  }
+
+  private async participateWithMessage(
+    channelId: string,
+    _teamId: string,
+    instructions: string,
+    input: string,
+  ): Promise<void> {
+    const response = await this.openAi.responses.create({
+      model: GPT_MODEL,
+      tools: [{ type: 'web_search_preview' }],
+      instructions,
+      input,
+      user: `participation-${channelId}-${_teamId}-DaBros2016`,
+    });
+
+    const result = extractAndParseOpenAiResponse(response);
+    if (result) {
+      await this.webService.sendMessage(channelId, result, [{ type: 'markdown', text: result }]);
+    }
+  }
+```
+
+Add the `Stream` and `ResponseStreamEvent` import at the top of `ai.service.ts` if the compiler requires it. The `for await` loop handles the `Stream<ResponseStreamEvent>` return type from `create({ stream: true })` automatically.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm run test:backend -- --testPathPattern="ai.service.spec" --verbose`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `npm run test:backend`
+Expected: All tests PASS, no regressions.
+
+- [ ] **Step 6: Verify the build compiles**
+
+Run: `npm run build:backend`
+Expected: Clean compilation.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/backend/src/ai/ai.service.ts packages/backend/src/ai/ai.service.spec.ts
+git commit -m "feat: stream @Moonbeam responses via Slack chatStream API
+
+When a user @mentions Moonbeam, the response now streams word-by-word
+with a native Slack shimmer loading indicator. Replies appear as
+threaded responses under the user's message. Falls back to the
+previous sendMessage() behavior when no thread context is available."
+```
+
+---
+
+### Task 5: Verify end-to-end and create PR
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run all tests**
+
+Run: `npm run test:backend`
+Expected: All tests PASS.
+
+- [ ] **Step 2: Run lint and format checks**
+
+Run: `npm run lint && npm run format:check`
+Expected: No errors.
+
+- [ ] **Step 3: Run the build**
+
+Run: `npm run build:backend`
+Expected: Clean compilation.
+
+- [ ] **Step 4: Create feature branch and push**
+
+```bash
+git checkout -b feature/streaming-responses
+git push -u origin feature/streaming-responses
+```
+
+- [ ] **Step 5: Create the PR**
+
+Create a PR against `dev-chat/mocker` upstream `master` branch with:
+
+- Title: `feat: stream @Moonbeam responses with shimmer UX and thread awareness`
+- Body summarizing: thread awareness fix, streaming via chatStream, fallback behavior
+- Note: requires enabling "Agents & AI Apps" in Slack app settings and reinstalling
+
+---
+
+## Prerequisites (Manual, before deploying)
+
+These are Slack admin tasks that must be done before the streaming feature works in production:
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) and select the Moonbeam app
+2. Enable **"Agents & AI Apps"** in the app settings
+3. This automatically adds the `assistant:write` scope
+4. Reinstall the app to the workspace to activate the new scope

--- a/docs/superpowers/specs/2026-03-27-streaming-responses-design.md
+++ b/docs/superpowers/specs/2026-03-27-streaming-responses-design.md
@@ -1,0 +1,164 @@
+# Streaming Responses & Thread Awareness for @Moonbeam
+
+**Date:** 2026-03-27
+**Status:** Draft
+**PR Target:** `dev-chat/mocker` upstream
+
+## Problem
+
+When a user `@Moonbeam`s in a channel or thread, two things are broken:
+
+1. **No feedback while processing.** The bot fetches 200 messages of history, calls OpenAI, and formats a response — all silently. The user has no indication Moonbeam is working.
+2. **No thread awareness.** The `Event` model doesn't capture `thread_ts`, so when someone @mentions Moonbeam inside a thread, the response posts to the channel instead of replying in-thread.
+
+## Solution
+
+Add thread awareness and use Slack's native streaming API (`chatStream()`) to stream Moonbeam's responses word-by-word with a shimmer loading indicator.
+
+## How It Works
+
+### User Experience
+
+1. User posts `@Moonbeam what do you think?` in a channel (or thread)
+2. A shimmer/loading indicator appears immediately as a threaded reply under the user's message
+3. Text streams in progressively as OpenAI generates it
+4. The final message locks in place with formatting
+
+For channel mentions, the user's message becomes the thread anchor — the streamed reply appears as a thread under it. Slack shows thread previews inline in the channel, so the response is visible without clicking into the thread.
+
+For thread mentions, the streamed reply appears directly in the existing thread.
+
+### Technical Flow
+
+```
+User @Moonbeam in channel/thread
+    |
+    v
+handle() receives EventRequest
+    |-- event.ts = message timestamp
+    |-- event.thread_ts = thread timestamp (if in a thread)
+    |
+    v
+threadTs = event.thread_ts ?? event.ts
+    |
+    v
+participate(teamId, channelId, text, userId, threadTs)
+    |
+    |-- 1. Fetch history, memories, custom prompt (unchanged)
+    |-- 2. Build system instructions (unchanged)
+    |
+    |-- 3. Start Slack stream
+    |       webService.startStream(channelId, threadTs)
+    |       -> shimmer appears immediately
+    |
+    |-- 4. Stream OpenAI response
+    |       openAi.responses.stream({ ..., stream: true })
+    |       for each text delta:
+    |           streamer.append({ markdown_text: delta })
+    |       -> text appears word-by-word in Slack
+    |
+    |-- 5. Finalize
+    |       streamer.stop()
+    |       -> final message locks in place
+    |
+    v
+Done
+```
+
+## Changes Required
+
+### 1. `Event` interface — `packages/backend/src/shared/models/slack/slack-models.ts`
+
+Add `thread_ts` to the `Event` interface. Slack already sends this field on every threaded message — the codebase just doesn't capture it.
+
+```typescript
+// Add to Event interface:
+thread_ts?: string;
+```
+
+Also add `ts` capture — the message timestamp is already in the interface but we need to ensure it's available for the thread anchor use case.
+
+### 2. `handle()` — `packages/backend/src/ai/ai.service.ts`
+
+Pass thread context into `participate()`. Use `thread_ts` if the message is in a thread, otherwise use the message's own `ts` as the thread anchor.
+
+```typescript
+// Determine thread context: reply in existing thread, or create one from the message
+const threadTs = request.event.thread_ts ?? request.event.ts;
+void this.participate(request.team_id, request.event.channel, request.event.text, request.event.user, threadTs);
+```
+
+### 3. `participate()` — `packages/backend/src/ai/ai.service.ts`
+
+**Signature change:** Add `threadTs` parameter.
+
+**Core change:** Replace the non-streaming OpenAI call + `sendMessage()` with:
+
+1. Start a Slack `ChatStreamer` via `webService.startStream()`
+2. Switch to OpenAI streaming (`responses.stream()` or `responses.create()` with `stream: true`)
+3. Loop over stream events, appending text deltas to the Slack streamer
+4. Call `streamer.stop()` to finalize
+
+**Error handling:** If streaming fails mid-way, catch the error and attempt to stop the stream cleanly. Log the error as today.
+
+**Fallback:** If `startStream` fails (e.g., missing scope), fall back to the current `sendMessage()` behavior so the bot doesn't silently fail.
+
+### 4. `WebService` — `packages/backend/src/shared/services/web/web.service.ts`
+
+Add a `startStream()` method that wraps `WebClient.chatStream()`:
+
+```typescript
+public startStream(channel: string, threadTs: string): ChatStreamer {
+  return this.web.chatStream({
+    channel,
+    thread_ts: threadTs,
+    token: process.env.MUZZLE_BOT_USER_TOKEN,
+  });
+}
+```
+
+The `ChatStreamer` class (from `@slack/web-api`) handles buffering (default 256 chars) and exposes `.append()` and `.stop()`.
+
+## Prerequisites
+
+### Slack App Configuration
+
+- Enable **"Agents & AI Apps"** in the Slack app settings dashboard
+- This automatically adds the `assistant:write` scope
+- Reinstall the app to the workspace to pick up the new scope
+- No guest users are affected (workspace has zero guests)
+
+### No SDK Changes Needed
+
+- `@slack/web-api ^7.15.0` already includes `chatStream()`, `ChatStreamer`, and all streaming types
+- OpenAI SDK `^4.103.0` already supports streaming via `responses.stream()` or `stream: true`
+
+## Files Modified
+
+| File                                                       | Change                                                                          |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `packages/backend/src/shared/models/slack/slack-models.ts` | Add `thread_ts` to `Event` interface                                            |
+| `packages/backend/src/ai/ai.service.ts`                    | Update `handle()` to pass `threadTs`; refactor `participate()` to use streaming |
+| `packages/backend/src/shared/services/web/web.service.ts`  | Add `startStream()` method                                                      |
+
+## Out of Scope
+
+- Streaming for slash command responses (`/ai`, `/ai-history`) — these use a different flow and can be addressed in a follow-up
+- `assistant.threads.setStatus` with `loading_messages` — the `chatStream()` shimmer is sufficient; explicit status messages are additive polish
+- Streaming for image generation — not applicable
+- Changes to the `redeployMoonbeam()` or `generateCorpoSpeak()` flows
+
+## Risks
+
+- **Agents & AI Apps scope:** Enabling this feature on the Slack app locks out workspace guests. Confirmed: zero guests in this workspace.
+- **Rate limits:** `chatStream()` buffers 256 chars by default before flushing, which helps avoid rate limits. If responses are very long, we may need to increase the buffer.
+- **OpenAI streaming with tools:** The `web_search_preview` tool is used in `participate()`. When streaming, tool calls arrive as separate events before the text response. We need to handle these correctly (wait for tool results, then stream the text).
+
+## Testing Plan
+
+- [ ] @Moonbeam in a channel — verify shimmer appears, text streams, final message renders correctly
+- [ ] @Moonbeam in an existing thread — verify reply stays in-thread with streaming
+- [ ] @Moonbeam when muzzled — verify no response (unchanged behavior)
+- [ ] @Moonbeam by Moonbeam itself — verify no self-reply (unchanged behavior)
+- [ ] OpenAI error mid-stream — verify stream stops cleanly, error is logged
+- [ ] Slack streaming API error — verify fallback to `sendMessage()`

--- a/packages/backend/src/ai/ai.service.spec.ts
+++ b/packages/backend/src/ai/ai.service.spec.ts
@@ -290,31 +290,6 @@ describe('AIService', () => {
       );
     });
 
-    it('passes event.ts as threadTs when not in a thread', async () => {
-      (aiService.slackService.containsTag as jest.Mock).mockReturnValue(true);
-      (aiService.slackService.isUserMentioned as jest.Mock).mockReturnValue(true);
-      (aiService.muzzlePersistenceService.isUserMuzzled as jest.Mock).mockResolvedValue(false);
-      const participateSpy = jest.spyOn(aiService, 'participate').mockResolvedValue();
-
-      await aiService.handle({
-        team_id: 'T1',
-        event: {
-          user: 'U1',
-          channel: 'C1',
-          text: `<@${MOONBEAM_SLACK_ID}> hello`,
-          ts: '1700000001.123456',
-        },
-      } as never);
-
-      expect(participateSpy).toHaveBeenCalledWith(
-        'T1',
-        'C1',
-        `<@${MOONBEAM_SLACK_ID}> hello`,
-        'U1',
-        '1700000001.123456',
-      );
-    });
-
     it('passes event.thread_ts as threadTs when in a thread', async () => {
       (aiService.slackService.containsTag as jest.Mock).mockReturnValue(true);
       (aiService.slackService.isUserMentioned as jest.Mock).mockReturnValue(true);
@@ -492,6 +467,8 @@ describe('AIService', () => {
       expect(mockAppend).toHaveBeenCalledWith({ markdown_text: 'Hello ' });
       expect(mockAppend).toHaveBeenCalledWith({ markdown_text: 'world!' });
       expect(mockStop).toHaveBeenCalled();
+      expect(aiService.redis.setHasParticipated).toHaveBeenCalledWith('T1', 'C1');
+      expect(aiService.redis.removeParticipationInFlight).toHaveBeenCalledWith('C1', 'T1');
     });
 
     it('falls back to sendMessage when threadTs is not provided', async () => {
@@ -543,6 +520,7 @@ describe('AIService', () => {
       );
 
       expect(mockStop).toHaveBeenCalled();
+      expect(aiService.redis.removeParticipationInFlight).toHaveBeenCalledWith('C1', 'T1');
     });
   });
 

--- a/packages/backend/src/ai/ai.service.spec.ts
+++ b/packages/backend/src/ai/ai.service.spec.ts
@@ -49,6 +49,10 @@ const buildAiService = (): AIService => {
 
   ai.webService = {
     sendMessage: jest.fn().mockResolvedValue({ ok: true }),
+    startStream: jest.fn().mockReturnValue({
+      append: jest.fn().mockResolvedValue(null),
+      stop: jest.fn().mockResolvedValue({ ok: true }),
+    }),
   } as unknown as AIService['webService'];
 
   ai.slackService = {
@@ -466,35 +470,83 @@ describe('AIService', () => {
   });
 
   describe('participate', () => {
-    it('should be defined', () => {
-      expect(aiService.participate).toBeDefined();
-    });
-
-    it('sends participation response and sets participation marker', async () => {
-      (aiService.historyService.getHistoryWithOptions as jest.Mock).mockResolvedValue([
-        { slackId: 'U2', name: 'Jane', message: 'Hello' },
-      ]);
-      (aiService.openAi.responses.create as jest.Mock).mockResolvedValue({
-        output: [{ type: 'message', content: [{ type: 'output_text', text: 'Participation response' }] }],
+    it('streams response to Slack when threadTs is provided', async () => {
+      const mockAppend = jest.fn().mockResolvedValue(null);
+      const mockStop = jest.fn().mockResolvedValue({ ok: true });
+      (aiService.webService.startStream as jest.Mock).mockReturnValue({
+        append: mockAppend,
+        stop: mockStop,
       });
-      (aiService.webService.sendMessage as jest.Mock).mockResolvedValue({ ok: true });
 
-      await aiService.participate('T1', 'C1', '<@moonbeam> hi');
-      await Promise.resolve();
+      const mockStream = {
+        async *[Symbol.asyncIterator]() {
+          yield { type: 'response.output_text.delta', delta: 'Hello ' };
+          yield { type: 'response.output_text.delta', delta: 'world!' };
+        },
+      };
+      (aiService.openAi.responses.create as jest.Mock).mockResolvedValue(mockStream);
 
-      expect(aiService.webService.sendMessage).toHaveBeenCalledWith('C1', 'Participation response', [
-        { type: 'markdown', text: 'Participation response' },
-      ]);
-      expect(aiService.redis.setHasParticipated).toHaveBeenCalledWith('T1', 'C1');
-      expect(aiService.redis.removeParticipationInFlight).toHaveBeenCalledWith('C1', 'T1');
+      await aiService.participate('T1', 'C1', 'hey @Moonbeam', 'U1', '1700000001.123456');
+
+      expect(aiService.webService.startStream).toHaveBeenCalledWith('C1', '1700000001.123456');
+      expect(mockAppend).toHaveBeenCalledWith({ markdown_text: 'Hello ' });
+      expect(mockAppend).toHaveBeenCalledWith({ markdown_text: 'world!' });
+      expect(mockStop).toHaveBeenCalled();
     });
 
-    it('throws when participate model call fails', async () => {
-      (aiService.historyService.getHistoryWithOptions as jest.Mock).mockResolvedValue([]);
-      (aiService.openAi.responses.create as jest.Mock).mockRejectedValue(new Error('model fail'));
+    it('falls back to sendMessage when threadTs is not provided', async () => {
+      (aiService.openAi.responses.create as jest.Mock).mockResolvedValue({
+        output: [{ type: 'message', content: [{ type: 'output_text', text: 'Response text' }] }],
+      });
 
-      await expect(aiService.participate('T1', 'C1', 'hi')).rejects.toThrow('model fail');
-      expect(aiService.redis.removeParticipationInFlight).toHaveBeenCalledWith('C1', 'T1');
+      await aiService.participate('T1', 'C1', 'hey @Moonbeam', 'U1');
+
+      expect(aiService.webService.startStream).not.toHaveBeenCalled();
+      expect(aiService.webService.sendMessage).toHaveBeenCalledWith(
+        'C1',
+        'Response text',
+        [{ type: 'markdown', text: 'Response text' }],
+      );
+    });
+
+    it('falls back to sendMessage when streaming throws', async () => {
+      (aiService.webService.startStream as jest.Mock).mockImplementation(() => {
+        throw new Error('streaming not available');
+      });
+      (aiService.openAi.responses.create as jest.Mock).mockResolvedValue({
+        output: [{ type: 'message', content: [{ type: 'output_text', text: 'Fallback text' }] }],
+      });
+
+      await aiService.participate('T1', 'C1', 'hey @Moonbeam', 'U1', '1700000001.123456');
+
+      expect(aiService.webService.sendMessage).toHaveBeenCalledWith(
+        'C1',
+        'Fallback text',
+        [{ type: 'markdown', text: 'Fallback text' }],
+      );
+    });
+
+    it('stops stream cleanly on OpenAI error', async () => {
+      const mockAppend = jest.fn().mockResolvedValue(null);
+      const mockStop = jest.fn().mockResolvedValue({ ok: true });
+      (aiService.webService.startStream as jest.Mock).mockReturnValue({
+        append: mockAppend,
+        stop: mockStop,
+      });
+
+      const mockStream = {
+        async *[Symbol.asyncIterator]() {
+          yield { type: 'response.output_text.delta', delta: 'partial' };
+          throw new Error('OpenAI stream error');
+        },
+      };
+      (aiService.openAi.responses.create as jest.Mock).mockResolvedValue(mockStream);
+
+      await expect(
+        aiService.participate('T1', 'C1', 'hey @Moonbeam', 'U1', '1700000001.123456'),
+      ).rejects.toThrow('OpenAI stream error');
+
+      expect(mockStop).toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/ai/ai.service.spec.ts
+++ b/packages/backend/src/ai/ai.service.spec.ts
@@ -273,10 +273,68 @@ describe('AIService', () => {
           user: 'U1',
           channel: 'C1',
           text: `<@${MOONBEAM_SLACK_ID}> hello`,
+          ts: '1700000001.000000',
         },
       } as never);
 
-      expect(participateSpy).toHaveBeenCalledWith('T1', 'C1', `<@${MOONBEAM_SLACK_ID}> hello`, 'U1');
+      expect(participateSpy).toHaveBeenCalledWith(
+        'T1',
+        'C1',
+        `<@${MOONBEAM_SLACK_ID}> hello`,
+        'U1',
+        '1700000001.000000',
+      );
+    });
+
+    it('passes event.ts as threadTs when not in a thread', async () => {
+      (aiService.slackService.containsTag as jest.Mock).mockReturnValue(true);
+      (aiService.slackService.isUserMentioned as jest.Mock).mockReturnValue(true);
+      (aiService.muzzlePersistenceService.isUserMuzzled as jest.Mock).mockResolvedValue(false);
+      const participateSpy = jest.spyOn(aiService, 'participate').mockResolvedValue();
+
+      await aiService.handle({
+        team_id: 'T1',
+        event: {
+          user: 'U1',
+          channel: 'C1',
+          text: `<@${MOONBEAM_SLACK_ID}> hello`,
+          ts: '1700000001.123456',
+        },
+      } as never);
+
+      expect(participateSpy).toHaveBeenCalledWith(
+        'T1',
+        'C1',
+        `<@${MOONBEAM_SLACK_ID}> hello`,
+        'U1',
+        '1700000001.123456',
+      );
+    });
+
+    it('passes event.thread_ts as threadTs when in a thread', async () => {
+      (aiService.slackService.containsTag as jest.Mock).mockReturnValue(true);
+      (aiService.slackService.isUserMentioned as jest.Mock).mockReturnValue(true);
+      (aiService.muzzlePersistenceService.isUserMuzzled as jest.Mock).mockResolvedValue(false);
+      const participateSpy = jest.spyOn(aiService, 'participate').mockResolvedValue();
+
+      await aiService.handle({
+        team_id: 'T1',
+        event: {
+          user: 'U1',
+          channel: 'C1',
+          text: `<@${MOONBEAM_SLACK_ID}> hello`,
+          ts: '1700000002.654321',
+          thread_ts: '1700000001.123456',
+        },
+      } as never);
+
+      expect(participateSpy).toHaveBeenCalledWith(
+        'T1',
+        'C1',
+        `<@${MOONBEAM_SLACK_ID}> hello`,
+        'U1',
+        '1700000001.123456',
+      );
     });
 
     it('does not participate if requesting user is muzzled', async () => {

--- a/packages/backend/src/ai/ai.service.spec.ts
+++ b/packages/backend/src/ai/ai.service.spec.ts
@@ -502,11 +502,9 @@ describe('AIService', () => {
       await aiService.participate('T1', 'C1', 'hey @Moonbeam', 'U1');
 
       expect(aiService.webService.startStream).not.toHaveBeenCalled();
-      expect(aiService.webService.sendMessage).toHaveBeenCalledWith(
-        'C1',
-        'Response text',
-        [{ type: 'markdown', text: 'Response text' }],
-      );
+      expect(aiService.webService.sendMessage).toHaveBeenCalledWith('C1', 'Response text', [
+        { type: 'markdown', text: 'Response text' },
+      ]);
     });
 
     it('falls back to sendMessage when streaming throws', async () => {
@@ -519,11 +517,9 @@ describe('AIService', () => {
 
       await aiService.participate('T1', 'C1', 'hey @Moonbeam', 'U1', '1700000001.123456');
 
-      expect(aiService.webService.sendMessage).toHaveBeenCalledWith(
-        'C1',
-        'Fallback text',
-        [{ type: 'markdown', text: 'Fallback text' }],
-      );
+      expect(aiService.webService.sendMessage).toHaveBeenCalledWith('C1', 'Fallback text', [
+        { type: 'markdown', text: 'Fallback text' },
+      ]);
     });
 
     it('stops stream cleanly on OpenAI error', async () => {
@@ -542,9 +538,9 @@ describe('AIService', () => {
       };
       (aiService.openAi.responses.create as jest.Mock).mockResolvedValue(mockStream);
 
-      await expect(
-        aiService.participate('T1', 'C1', 'hey @Moonbeam', 'U1', '1700000001.123456'),
-      ).rejects.toThrow('OpenAI stream error');
+      await expect(aiService.participate('T1', 'C1', 'hey @Moonbeam', 'U1', '1700000001.123456')).rejects.toThrow(
+        'OpenAI stream error',
+      );
 
       expect(mockStop).toHaveBeenCalled();
     });

--- a/packages/backend/src/ai/ai.service.ts
+++ b/packages/backend/src/ai/ai.service.ts
@@ -438,7 +438,7 @@ export class AIService {
       });
   }
 
-  public async participate(teamId: string, channelId: string, taggedMessage: string, userId?: string): Promise<void> {
+  public async participate(teamId: string, channelId: string, taggedMessage: string, userId?: string, threadTs?: string): Promise<void> {
     await this.redis.setParticipationInFlight(channelId, teamId);
 
     const historyMessages = await this.historyService.getHistoryWithOptions({
@@ -784,7 +784,14 @@ export class AIService {
       const isMoonbeamTagged = this.slackService.isUserMentioned(request.event.text, MOONBEAM_SLACK_ID);
       const isPosterMoonbeam = request.event.user === MOONBEAM_SLACK_ID;
       if (isMoonbeamTagged && !isPosterMoonbeam) {
-        void this.participate(request.team_id, request.event.channel, request.event.text, request.event.user);
+        const threadTs = request.event.thread_ts ?? request.event.ts;
+        void this.participate(
+          request.team_id,
+          request.event.channel,
+          request.event.text,
+          request.event.user,
+          threadTs,
+        );
       }
     }
   }

--- a/packages/backend/src/ai/ai.service.ts
+++ b/packages/backend/src/ai/ai.service.ts
@@ -835,13 +835,7 @@ export class AIService {
       const isPosterMoonbeam = request.event.user === MOONBEAM_SLACK_ID;
       if (isMoonbeamTagged && !isPosterMoonbeam) {
         const threadTs = request.event.thread_ts ?? request.event.ts;
-        void this.participate(
-          request.team_id,
-          request.event.channel,
-          request.event.text,
-          request.event.user,
-          threadTs,
-        );
+        void this.participate(request.team_id, request.event.channel, request.event.text, request.event.user, threadTs);
       }
     }
   }

--- a/packages/backend/src/ai/ai.service.ts
+++ b/packages/backend/src/ai/ai.service.ts
@@ -438,64 +438,114 @@ export class AIService {
       });
   }
 
-  public async participate(teamId: string, channelId: string, taggedMessage: string, userId?: string, threadTs?: string): Promise<void> {
+  public async participate(
+    teamId: string,
+    channelId: string,
+    taggedMessage: string,
+    userId?: string,
+    threadTs?: string,
+  ): Promise<void> {
     await this.redis.setParticipationInFlight(channelId, teamId);
 
-    const historyMessages = await this.historyService.getHistoryWithOptions({
-      teamId,
-      channelId,
-      maxMessages: 200,
-      timeWindowMinutes: 120,
-    });
+    try {
+      const historyMessages = await this.historyService.getHistoryWithOptions({
+        teamId,
+        channelId,
+        maxMessages: 200,
+        timeWindowMinutes: 120,
+      });
 
-    const history = this.formatHistory(historyMessages);
+      const history = this.formatHistory(historyMessages);
 
-    const customPrompt = userId ? await this.slackPersistenceService.getCustomPrompt(userId, teamId) : null;
-    const normalizedCustomPrompt = customPrompt?.trim() || null;
+      const customPrompt = userId ? await this.slackPersistenceService.getCustomPrompt(userId, teamId) : null;
+      const normalizedCustomPrompt = customPrompt?.trim() || null;
 
-    // Fetch and select relevant memories
-    const participantSlackIds = this.extractParticipantSlackIds(historyMessages, {
-      excludeSlackIds: [MOONBEAM_SLACK_ID],
-    });
-    const memoryContext = await this.fetchMemoryContext(participantSlackIds, teamId, history, historyMessages);
-    const baseInstructions = normalizedCustomPrompt ?? MOONBEAM_SYSTEM_INSTRUCTIONS;
-    const systemInstructions = this.appendMemoryContext(baseInstructions, memoryContext);
+      const participantSlackIds = this.extractParticipantSlackIds(historyMessages, {
+        excludeSlackIds: [MOONBEAM_SLACK_ID],
+      });
+      const memoryContext = await this.fetchMemoryContext(participantSlackIds, teamId, history, historyMessages);
+      const baseInstructions = normalizedCustomPrompt ?? MOONBEAM_SYSTEM_INSTRUCTIONS;
+      const systemInstructions = this.appendMemoryContext(baseInstructions, memoryContext);
 
-    const input = `${history}\n\n---\n[Tagged message to respond to]:\n${taggedMessage}`;
+      const input = `${history}\n\n---\n[Tagged message to respond to]:\n${taggedMessage}`;
 
-    return this.openAi.responses
-      .create({
+      if (threadTs) {
+        await this.participateWithStreaming(channelId, teamId, systemInstructions, input, threadTs);
+      } else {
+        await this.participateWithMessage(channelId, teamId, systemInstructions, input);
+      }
+
+      await this.redis.setHasParticipated(teamId, channelId);
+    } catch (e) {
+      logError(this.aiServiceLogger, 'Failed to generate AI participation response', e, {
+        teamId,
+        channelId,
+        taggedMessage,
+      });
+      throw e;
+    } finally {
+      void this.redis.removeParticipationInFlight(channelId, teamId);
+    }
+  }
+
+  private async participateWithStreaming(
+    channelId: string,
+    teamId: string,
+    instructions: string,
+    input: string,
+    threadTs: string,
+  ): Promise<void> {
+    let streamer;
+    try {
+      streamer = this.webService.startStream(channelId, threadTs);
+    } catch (e) {
+      this.aiServiceLogger.warn('Failed to start Slack stream, falling back to sendMessage', e);
+      return this.participateWithMessage(channelId, teamId, instructions, input);
+    }
+
+    try {
+      const stream = await this.openAi.responses.create({
         model: GPT_MODEL,
         tools: [{ type: 'web_search_preview' }],
-        instructions: systemInstructions,
+        instructions,
         input,
+        stream: true,
         user: `participation-${channelId}-${teamId}-DaBros2016`,
-      })
-      .then((x) => extractAndParseOpenAiResponse(x))
-      .then((result) => {
-        if (result) {
-          this.webService
-            .sendMessage(channelId, result, [{ type: 'markdown', text: result }])
-            .then(() => this.redis.setHasParticipated(teamId, channelId))
-            .catch((e) =>
-              logError(this.aiServiceLogger, 'Failed to send AI participation message', e, {
-                teamId,
-                channelId,
-              }),
-            );
-        }
-      })
-      .catch(async (e) => {
-        logError(this.aiServiceLogger, 'Failed to generate AI participation response', e, {
-          teamId,
-          channelId,
-          taggedMessage,
-        });
-        throw e;
-      })
-      .finally(() => {
-        void this.redis.removeParticipationInFlight(channelId, teamId);
       });
+
+      for await (const event of stream) {
+        if (event.type === 'response.output_text.delta') {
+          await streamer.append({ markdown_text: event.delta });
+        }
+      }
+
+      await streamer.stop();
+    } catch (e) {
+      await streamer.stop().catch((stopErr: unknown) => {
+        this.aiServiceLogger.warn('Failed to stop stream after error', stopErr);
+      });
+      throw e;
+    }
+  }
+
+  private async participateWithMessage(
+    channelId: string,
+    _teamId: string,
+    instructions: string,
+    input: string,
+  ): Promise<void> {
+    const response = await this.openAi.responses.create({
+      model: GPT_MODEL,
+      tools: [{ type: 'web_search_preview' }],
+      instructions,
+      input,
+      user: `participation-${channelId}-${_teamId}-DaBros2016`,
+    });
+
+    const result = extractAndParseOpenAiResponse(response);
+    if (result) {
+      await this.webService.sendMessage(channelId, result, [{ type: 'markdown', text: result }]);
+    }
   }
 
   private async selectRelevantMemories(

--- a/packages/backend/src/ai/ai.service.ts
+++ b/packages/backend/src/ai/ai.service.ts
@@ -530,7 +530,7 @@ export class AIService {
 
   private async participateWithMessage(
     channelId: string,
-    _teamId: string,
+    teamId: string,
     instructions: string,
     input: string,
   ): Promise<void> {
@@ -539,7 +539,7 @@ export class AIService {
       tools: [{ type: 'web_search_preview' }],
       instructions,
       input,
-      user: `participation-${channelId}-${_teamId}-DaBros2016`,
+      user: `participation-${channelId}-${teamId}-DaBros2016`,
     });
 
     const result = extractAndParseOpenAiResponse(response);

--- a/packages/backend/src/shared/models/slack/slack-models.ts
+++ b/packages/backend/src/shared/models/slack/slack-models.ts
@@ -43,6 +43,7 @@ export interface Event {
   user: string;
   username: string;
   ts: string;
+  thread_ts?: string;
   channel: string;
   event_ts: string;
   channel_type: string;

--- a/packages/backend/src/shared/services/web/web.service.spec.ts
+++ b/packages/backend/src/shared/services/web/web.service.spec.ts
@@ -10,6 +10,7 @@ type MockWebClient = {
   users: { list: jest.Mock };
   conversations: { list: jest.Mock };
   files: { upload: jest.Mock };
+  chatStream: jest.Mock;
 };
 
 type WebServicePrivate = WebService & { web: MockWebClient };
@@ -130,6 +131,22 @@ describe('WebService', () => {
       expect(mockWebClient.chat.update).toHaveBeenCalledWith(
         expect.objectContaining({ channel: 'C1', text: 'updated', ts: '1.23' }),
       );
+    });
+  });
+
+  describe('startStream', () => {
+    it('calls chatStream with channel, thread_ts, and token', () => {
+      const streamer = webService.startStream('C1', '1700000001.123456');
+
+      expect(mockWebClient.chatStream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'C1',
+          thread_ts: '1700000001.123456',
+        }),
+      );
+      expect(streamer).toBeDefined();
+      expect(streamer.append).toBeDefined();
+      expect(streamer.stop).toBeDefined();
     });
   });
 

--- a/packages/backend/src/shared/services/web/web.service.ts
+++ b/packages/backend/src/shared/services/web/web.service.ts
@@ -11,6 +11,7 @@ import type {
   UsersListResponse,
 } from '@slack/web-api';
 import { WebClient } from '@slack/web-api';
+import type { ChatStreamer } from '@slack/web-api/dist/chat-stream';
 import { logError } from '../../logger/error-logging';
 import { logger } from '../../logger/logger';
 
@@ -142,6 +143,14 @@ export class WebService {
         text,
       }),
     );
+  }
+
+  public startStream(channel: string, threadTs: string): ChatStreamer {
+    return this.web.chatStream({
+      channel,
+      thread_ts: threadTs,
+      token: process.env.MUZZLE_BOT_USER_TOKEN,
+    });
   }
 
   public getAllUsers(): Promise<UsersListResponse> {

--- a/packages/backend/src/shared/services/web/web.service.ts
+++ b/packages/backend/src/shared/services/web/web.service.ts
@@ -11,7 +11,7 @@ import type {
   UsersListResponse,
 } from '@slack/web-api';
 import { WebClient } from '@slack/web-api';
-import type { ChatStreamer } from '@slack/web-api/dist/chat-stream';
+import type { ChatStreamer } from '@slack/web-api';
 import { logError } from '../../logger/error-logging';
 import { logger } from '../../logger/logger';
 

--- a/packages/backend/src/test/mocks/slack-web-api.mock.ts
+++ b/packages/backend/src/test/mocks/slack-web-api.mock.ts
@@ -22,6 +22,11 @@ export class WebClient {
     upload: jest.fn().mockResolvedValue(okResult()),
   };
 
+  chatStream = jest.fn().mockReturnValue({
+    append: jest.fn().mockResolvedValue(null),
+    stop: jest.fn().mockResolvedValue(okResult()),
+  });
+
   constructor(_token?: string) {
     void _token;
   }


### PR DESCRIPTION
## Summary

- **Thread awareness:** Moonbeam now replies in-thread when @mentioned inside a thread. Previously, all responses went to the channel regardless. This works because Slack already sends `thread_ts` on threaded messages — the bot just wasn't reading it.
- **Streaming responses:** When a user @mentions Moonbeam, the response streams word-by-word with Slack's native shimmer loading indicator via `chatStream()`. The reply appears as a threaded reply under the user's message.
- **Fallback:** If streaming fails for any reason, Moonbeam falls back to the existing `sendMessage()` behavior — no silent failures.

## How it works

The user's message `ts` (or `thread_ts` if already in a thread) is passed to `participate()`, which starts a Slack `ChatStreamer` and calls OpenAI with `stream: true`. Each text delta is appended to the stream in real time. When the response is complete, the stream is finalized.

## Slack app configuration

No changes to the Slack app settings are required. The streaming APIs (`chat.startStream` / `chat.appendStream` / `chat.stopStream`) only require the `chat:write` scope, which Moonbeam already has. Enabling "Agents & AI Apps" is **not** needed — that would add an assistant side panel in DMs, which is unnecessary and would waste tokens.

## Files changed

| File | Change |
|------|--------|
| `slack-models.ts` | Add `thread_ts` to `Event` interface |
| `web.service.ts` | Add `startStream()` method wrapping `chatStream()` |
| `ai.service.ts` | Thread-aware `handle()`, streaming `participate()` with fallback |
| `slack-web-api.mock.ts` | Add `chatStream` mock |
| `web.service.spec.ts` | Tests for `startStream()` |
| `ai.service.spec.ts` | Tests for thread passthrough, streaming, fallback, error cleanup |

## Test plan

- [ ] @Moonbeam in a channel — verify shimmer appears, text streams, final message renders
- [ ] @Moonbeam in an existing thread — verify reply stays in-thread with streaming
- [ ] @Moonbeam when muzzled — verify no response (unchanged)
- [ ] OpenAI error mid-stream — verify stream stops cleanly, error logged