### PR TITLE
Fixed auth

### DIFF
--- a/packages/backend/src/auth/auth.const.ts
+++ b/packages/backend/src/auth/auth.const.ts
@@ -1,4 +1,3 @@
-export const ALLOWED_TEAM_DOMAIN = 'dabros2016';
 export const SLACK_AUTH_URL = 'https://slack.com/oauth/v2/authorize';
 export const SLACK_TOKEN_URL = 'https://slack.com/api/oauth.v2.access';
 export const SLACK_IDENTITY_URL = 'https://slack.com/api/users.identity';

--- a/packages/backend/src/auth/auth.controller.spec.ts
+++ b/packages/backend/src/auth/auth.controller.spec.ts
@@ -27,6 +27,7 @@ describe('authController', () => {
       SLACK_CLIENT_SECRET: 'test-client-secret',
       SLACK_REDIRECT_URI: 'http://localhost:3000/auth/slack/callback',
       SEARCH_FRONTEND_URL: 'http://localhost:5173',
+      ALLOWED_TEAM_DOMAIN: 'T123',
     };
   });
 
@@ -75,7 +76,11 @@ describe('authController', () => {
         data: { ok: true, authed_user: { id: 'U123', access_token: 'xoxp-token' } },
       });
       (Axios.get as jest.Mock).mockResolvedValue({
-        data: { ok: true, user: { id: 'U123', name: 'alice' }, team: { name: 'dabros2016', id: 'T123' } },
+        data: {
+          ok: true,
+          user: { id: 'U123', name: 'alice' },
+          team: { name: 'T123', id: 'T123' },
+        },
       });
 
       const res = await request(app)
@@ -163,12 +168,12 @@ describe('authController', () => {
       expect(res.headers.location).toContain('auth_error=token_exchange_failed');
     });
 
-    it('redirects with auth_error=unauthorized_workspace when team domain is wrong', async () => {
+    it('redirects with auth_error=unauthorized_workspace when team id is wrong', async () => {
       (Axios.post as jest.Mock).mockResolvedValue({
         data: { ok: true, authed_user: { id: 'U999', access_token: 'xoxp-other' } },
       });
       (Axios.get as jest.Mock).mockResolvedValue({
-        data: { ok: true, user: { id: 'U999', name: 'bob' }, team: { domain: 'otherworkspace', id: 'T999' } },
+        data: { ok: true, user: { id: 'U999', name: 'bob' }, team: { name: 'otherworkspace', id: 'T999' } },
       });
 
       const res = await request(app)

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -7,7 +7,6 @@ import { createSessionToken } from '../shared/utils/session-token';
 import { logError } from '../shared/logger/error-logging';
 import { logger } from '../shared/logger/logger';
 import {
-  ALLOWED_TEAM_DOMAIN,
   SLACK_AUTH_URL,
   SLACK_TOKEN_URL,
   SLACK_IDENTITY_URL,
@@ -106,12 +105,10 @@ authController.get('/slack/callback', (req, res) => {
       headers: { Authorization: `Bearer ${tokenResponse.data.authed_user.access_token}` },
     });
 
-    const teamDomain = identityResponse.data.team?.name;
     const teamId = identityResponse.data.team?.id;
     const userId = identityResponse.data.user?.id;
-    if (!identityResponse.data.ok || teamDomain !== ALLOWED_TEAM_DOMAIN || !userId || !teamId) {
+    if (!identityResponse.data.ok || !userId || !teamId || teamId !== process.env.ALLOWED_TEAM_DOMAIN) {
       logError(authLogger, 'Unauthorized Slack workspace attempted to authenticate', {
-        teamDomain,
         teamId,
         userId,
       });
@@ -119,7 +116,7 @@ authController.get('/slack/callback', (req, res) => {
       return;
     }
 
-    const sessionToken = createSessionToken(userId, teamDomain, teamId);
+    const sessionToken = createSessionToken(userId, teamId);
     res.redirect(`${frontendUrl}#token=${sessionToken}`);
   })().catch((e: unknown) => {
     logError(authLogger, 'Slack OAuth callback failed', e, {});

--- a/packages/backend/src/search/search.controller.spec.ts
+++ b/packages/backend/src/search/search.controller.spec.ts
@@ -15,9 +15,8 @@ describe('searchController', () => {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as { authSession?: { userId: string; teamDomain: string; teamId: string; exp: number } }).authSession = {
+    (req as { authSession?: { userId: string; teamId: string; exp: number } }).authSession = {
       userId: 'U1',
-      teamDomain: 'dabros2016',
       teamId: 'T1',
       exp: Date.now() + 60000,
     };
@@ -96,9 +95,9 @@ describe('searchController', () => {
     const appWithoutTeam = express();
     appWithoutTeam.use(express.json());
     appWithoutTeam.use((req, _res, next) => {
-      (req as { authSession?: { userId: string; teamDomain: string; exp: number } }).authSession = {
+      (req as { authSession?: { userId: string; teamId: string; exp: number } }).authSession = {
         userId: 'U1',
-        teamDomain: 'dabros2016',
+        teamId: '',
         exp: Date.now() + 60000,
       };
       next();

--- a/packages/backend/src/shared/middleware/authMiddleware.spec.ts
+++ b/packages/backend/src/shared/middleware/authMiddleware.spec.ts
@@ -28,7 +28,7 @@ describe('authMiddleware', () => {
   });
 
   it('calls next for a valid Bearer token', () => {
-    const token = createSessionToken('U1', 'dabros2016', 'T1');
+    const token = createSessionToken('U1', 'T1');
     const req = makeReq(`Bearer ${token}`);
     const res = makeRes();
     const next = jest.fn() as unknown as NextFunction;
@@ -41,7 +41,7 @@ describe('authMiddleware', () => {
   });
 
   it('returns 401 when verified token payload has no teamId', () => {
-    const token = createSessionToken('U1', 'dabros2016');
+    const token = createSessionToken('U1', '');
     const req = makeReq(`Bearer ${token}`);
     const res = makeRes();
     const next = jest.fn() as unknown as NextFunction;

--- a/packages/backend/src/shared/utils/session-token.model.ts
+++ b/packages/backend/src/shared/utils/session-token.model.ts
@@ -1,6 +1,5 @@
 export interface SessionPayload {
   userId: string;
-  teamDomain: string;
-  teamId?: string;
+  teamId: string;
   exp: number;
 }

--- a/packages/backend/src/shared/utils/session-token.spec.ts
+++ b/packages/backend/src/shared/utils/session-token.spec.ts
@@ -19,12 +19,12 @@ describe('session-token', () => {
       expect(token).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
     });
 
-    it('embeds userId and teamDomain in the payload', () => {
+    it('embeds userId and teamId in the payload', () => {
       const token = createSessionToken('U456', 'myteam');
       const [payload] = token.split('.');
       const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString());
       expect(decoded.userId).toBe('U456');
-      expect(decoded.teamDomain).toBe('myteam');
+      expect(decoded.teamId).toBe('myteam');
     });
 
     it('sets an expiry timestamp in the future', () => {
@@ -53,7 +53,7 @@ describe('session-token', () => {
       const result = verifySessionToken(token);
       expect(result).not.toBeNull();
       expect(result?.userId).toBe('U789');
-      expect(result?.teamDomain).toBe('goodteam');
+      expect(result?.teamId).toBe('goodteam');
     });
 
     it('returns null for a token with no dot separator', () => {

--- a/packages/backend/src/shared/utils/session-token.ts
+++ b/packages/backend/src/shared/utils/session-token.ts
@@ -2,8 +2,6 @@ import crypto from 'crypto';
 import { TOKEN_TTL_MS } from './session-token.const';
 import type { SessionPayload } from './session-token.model';
 
-export type { SessionPayload };
-
 function getSecret(): string {
   const secret = process.env.SEARCH_AUTH_SECRET;
   if (!secret) {
@@ -15,10 +13,10 @@ function getSecret(): string {
   return secret;
 }
 
-export function createSessionToken(userId: string, teamDomain: string, teamId?: string): string {
+export function createSessionToken(userId: string, teamId: string): string {
   const payloadData: SessionPayload = {
     userId,
-    teamDomain,
+    teamId,
     exp: Date.now() + TOKEN_TTL_MS,
     ...(teamId ? { teamId } : {}),
   };
@@ -34,7 +32,7 @@ function isSessionPayload(value: unknown): value is SessionPayload {
   }
   return (
     typeof Reflect.get(value, 'userId') === 'string' &&
-    typeof Reflect.get(value, 'teamDomain') === 'string' &&
+    typeof Reflect.get(value, 'teamId') === 'string' &&
     (Reflect.get(value, 'teamId') === undefined || typeof Reflect.get(value, 'teamId') === 'string') &&
     typeof Reflect.get(value, 'exp') === 'number'
   );


### PR DESCRIPTION
This pull request updates the authentication flow to use the Slack team ID (`teamId`) instead of the team domain (`teamDomain`) for validating and storing workspace information. The change simplifies session payloads and related logic, ensuring that workspace authorization and session handling are consistent and based on a unique identifier.

**Authentication and session changes:**

* Updated the authentication logic in `auth.controller.ts` to validate Slack workspaces using `teamId` (from environment variable `ALLOWED_TEAM_DOMAIN`) instead of `teamDomain`, and removed all references to `teamDomain` in session creation and validation. [[1]](diffhunk://#diff-752e0cb18c979d3edc353e2f80f87cbca25d9fe7a9354b848067f33f4f1501b6L10) [[2]](diffhunk://#diff-752e0cb18c979d3edc353e2f80f87cbca25d9fe7a9354b848067f33f4f1501b6L109-R119) [[3]](diffhunk://#diff-b5151bc44c0c7eb03922039e0d6d705b9420a1c396c0807df387a1326d6ef57bL1) [[4]](diffhunk://#diff-44959969208b88aa42d8689ba365ecb3eeaabeef12c02d1d157f342e20aea764L78-R83) [[5]](diffhunk://#diff-44959969208b88aa42d8689ba365ecb3eeaabeef12c02d1d157f342e20aea764L166-R176)
* Modified the `SessionPayload` interface and `createSessionToken` function to remove `teamDomain` and require `teamId` as a string. [[1]](diffhunk://#diff-317a148ba96da1b439e19bbd6235e425040cc25d5c58c5e955dae739d39a089aL3-R3) [[2]](diffhunk://#diff-ad91b2839b139ef276c02c342044df090ce5904701476aec17e367219d47ff60L18-R19)
* Updated the session token utility and its type checks to use `teamId` instead of `teamDomain`. [[1]](diffhunk://#diff-ad91b2839b139ef276c02c342044df090ce5904701476aec17e367219d47ff60L37-R35) [[2]](diffhunk://#diff-ad91b2839b139ef276c02c342044df090ce5904701476aec17e367219d47ff60L5-L6)

**Test updates:**

* Refactored all tests and test data to use `teamId` instead of `teamDomain` in session payloads, mocks, and assertions. [[1]](diffhunk://#diff-44959969208b88aa42d8689ba365ecb3eeaabeef12c02d1d157f342e20aea764R30) [[2]](diffhunk://#diff-74dce61f683c96934491016ca4dc2b2e5a6979442807f9fb25da93b90507e423L18-L20) [[3]](diffhunk://#diff-74dce61f683c96934491016ca4dc2b2e5a6979442807f9fb25da93b90507e423L99-R100) [[4]](diffhunk://#diff-bf9fceace8be05e0f181b8312f3dea618560a42691d8b05105b2b7f7a27a068aL31-R31) [[5]](diffhunk://#diff-bf9fceace8be05e0f181b8312f3dea618560a42691d8b05105b2b7f7a27a068aL44-R44) [[6]](diffhunk://#diff-80fa62b9b92e49bf0611bb9b142fb6ef56d1a7276a35cdbbe0ab01397a8de196L22-R27) [[7]](diffhunk://#diff-80fa62b9b92e49bf0611bb9b142fb6ef56d1a7276a35cdbbe0ab01397a8de196L56-R56)

These updates ensure that workspace authorization is more robust and less prone to ambiguity, as `teamId` is a unique and stable identifier provided by Slack.