### PR TITLE
Mild formatting changes

### DIFF
--- a/packages/backend/src/ai/ai.service.spec.ts
+++ b/packages/backend/src/ai/ai.service.spec.ts
@@ -223,7 +223,7 @@ describe('AIService', () => {
         'Moonbeam has been deployed.',
         expect.arrayContaining([
           expect.objectContaining({ type: 'image', image_url: 'https://muzzle.lol/deploy.png' }),
-          expect.objectContaining({ type: 'markdown', text: '"A quote"' }),
+          expect.objectContaining({ type: 'markdown', text: '_"A quote"_' }),
           expect.objectContaining({ type: 'markdown', text: '*Release changelog*\n- tightened auth' }),
         ]),
       );

--- a/packages/backend/src/ai/ai.service.ts
+++ b/packages/backend/src/ai/ai.service.ts
@@ -264,10 +264,8 @@ export class AIService {
             image_url: imageUrl,
             alt_text: 'Moonbeam has been deployed.',
           },
-          { type: 'markdown', text: quote ? `"${quote}"` : '' },
-          {
-            type: 'divider',
-          },
+          ...(quote ? ([{ type: 'markdown', text: `_"${quote}"_` }] satisfies KnownBlock[]) : []),
+          { type: 'divider' },
           {
             type: 'markdown',
             text: changelog,


### PR DESCRIPTION
This pull request makes a minor update to the formatting of quotes in AI service messages to improve their appearance. Specifically, quotes are now rendered in italicized markdown format instead of plain text.

- Formatting improvements:
  * Quotes are now wrapped in underscores for italics in markdown blocks (e.g., `_"A quote"_` instead of `"A quote"`), both in the `AIService` class and its corresponding test. [[1]](diffhunk://#diff-b948ab5725b6fd8df14455c99a4eefb5b642b5c0798e3d9aa3581c18ab52ec7cL267-R268) [[2]](diffhunk://#diff-009267b50bda07d536a6fed9fa606b821506c63060869f1eb547d46dad2055f2L226-R226)