### PR TITLE
Added support to FE to view memories and traits

### DIFF
--- a/packages/backend/src/dashboard/dashboard.controller.ts
+++ b/packages/backend/src/dashboard/dashboard.controller.ts
@@ -6,10 +6,14 @@ import { logger } from '../shared/logger/logger';
 import type { RequestWithAuthSession } from '../shared/models/express/RequestWithAuthSession';
 import { DEFAULT_PERIOD, VALID_PERIODS } from './dashboard.const';
 import type { TimePeriod } from './dashboard.model';
+import { MemoryPersistenceService } from '../ai/memory/memory.persistence.service';
+import { TraitPersistenceService } from '../trait/trait.persistence.service';
 
 export const dashboardController: Router = express.Router();
 
 const dashboardPersistenceService = new DashboardPersistenceService();
+const memoryPersistenceService = new MemoryPersistenceService();
+const traitPersistenceService = new TraitPersistenceService();
 const dashboardLogger = logger.child({ module: 'DashboardController' });
 
 function parsePeriod(value: unknown): TimePeriod {
@@ -34,6 +38,38 @@ dashboardController.get('/', (req: RequestWithAuthSession, res) => {
     .then((data) => res.status(200).json(data))
     .catch((e: unknown) => {
       logError(dashboardLogger, 'Failed to load dashboard data', e, { userId, teamId });
+      res.status(500).send();
+    });
+});
+
+dashboardController.get('/personal-context', (req: RequestWithAuthSession, res) => {
+  const { teamId, userId } = req.authSession || {};
+
+  if (!teamId || !userId) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  Promise.all([
+    memoryPersistenceService.getAllMemoriesForUser(userId, teamId),
+    traitPersistenceService.getAllTraitsForUser(userId, teamId),
+  ])
+    .then(([memories, traits]) => {
+      res.status(200).json({
+        memories: memories.map((memory) => ({
+          id: memory.id,
+          content: memory.content,
+          updatedAt: new Date(memory.updatedAt).toISOString(),
+        })),
+        traits: traits.map((trait) => ({
+          id: trait.id,
+          content: trait.content,
+          updatedAt: new Date(trait.updatedAt).toISOString(),
+        })),
+      });
+    })
+    .catch((e: unknown) => {
+      logError(dashboardLogger, 'Failed to load personal context data', e, { userId, teamId });
       res.status(500).send();
     });
 });

--- a/packages/backend/src/dashboard/dashboard.model.ts
+++ b/packages/backend/src/dashboard/dashboard.model.ts
@@ -39,3 +39,14 @@ export interface DashboardResponse {
   leaderboard: LeaderboardEntry[];
   repLeaderboard: RepLeaderboardEntry[];
 }
+
+export interface PersonalContextEntry {
+  id: number;
+  content: string;
+  updatedAt: string;
+}
+
+export interface PersonalContextResponse {
+  memories: PersonalContextEntry[];
+  traits: PersonalContextEntry[];
+}

--- a/packages/frontend/src/app.model.ts
+++ b/packages/frontend/src/app.model.ts
@@ -64,3 +64,14 @@ export interface DashboardResponse {
   leaderboard: LeaderboardEntry[];
   repLeaderboard: RepLeaderboardEntry[];
 }
+
+export interface PersonalContextEntry {
+  id: number;
+  content: string;
+  updatedAt: string;
+}
+
+export interface PersonalContextResponse {
+  memories: PersonalContextEntry[];
+  traits: PersonalContextEntry[];
+}

--- a/packages/frontend/src/components/AppShell.model.ts
+++ b/packages/frontend/src/components/AppShell.model.ts
@@ -1,6 +1,6 @@
 import type { ElementType } from 'react';
 
-export type Page = 'home' | 'message-search';
+export type Page = 'home' | 'message-search' | 'personal-context';
 
 export interface NavItemProps {
   icon: ElementType;

--- a/packages/frontend/src/components/AppShell.spec.tsx
+++ b/packages/frontend/src/components/AppShell.spec.tsx
@@ -29,6 +29,13 @@ describe('AppShell', () => {
     expect(screen.queryByRole('heading', { name: /^home$/i })).not.toBeInTheDocument();
   });
 
+  it('switches to the Memories + Traits page when its nav button is clicked', () => {
+    render(<AppShell onLogout={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /memories \+ traits/i }));
+    expect(screen.getByRole('heading', { name: /your memory \+ traits/i })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^home$/i })).not.toBeInTheDocument();
+  });
+
   it('calls onLogout when the Sign out button is clicked', () => {
     const onLogout = vi.fn();
     render(<AppShell onLogout={onLogout} />);

--- a/packages/frontend/src/components/AppShell.tsx
+++ b/packages/frontend/src/components/AppShell.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { Home, Search, LogOut } from 'lucide-react';
+import { Home, Search, Brain, LogOut } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { HomePage } from '@/pages/HomePage';
 import { MessageSearchPage } from '@/pages/MessageSearchPage';
+import { PersonalContextPage } from '@/pages/PersonalContextPage';
 import type { Page, NavItemProps, AppShellProps } from '@/components/AppShell.model';
 
 function NavItem({ icon: Icon, label, active, onClick }: NavItemProps) {
@@ -42,6 +43,12 @@ export function AppShell({ onLogout }: AppShellProps) {
             active={currentPage === 'message-search'}
             onClick={() => setCurrentPage('message-search')}
           />
+          <NavItem
+            icon={Brain}
+            label="Memories + Traits"
+            active={currentPage === 'personal-context'}
+            onClick={() => setCurrentPage('personal-context')}
+          />
         </nav>
 
         <Separator />
@@ -54,7 +61,9 @@ export function AppShell({ onLogout }: AppShellProps) {
 
       {/* Main content */}
       <main className="flex-1 overflow-y-auto">
-        {currentPage === 'home' ? <HomePage onLogout={onLogout} /> : <MessageSearchPage onLogout={onLogout} />}
+        {currentPage === 'home' && <HomePage onLogout={onLogout} />}
+        {currentPage === 'message-search' && <MessageSearchPage onLogout={onLogout} />}
+        {currentPage === 'personal-context' && <PersonalContextPage onLogout={onLogout} />}
       </main>
     </div>
   );

--- a/packages/frontend/src/hooks/usePersonalContext.spec.ts
+++ b/packages/frontend/src/hooks/usePersonalContext.spec.ts
@@ -1,0 +1,65 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { usePersonalContext } from '@/hooks/usePersonalContext';
+import { AUTH_TOKEN_KEY } from '@/app.const';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const mockData = {
+  memories: [{ id: 1, content: 'Loves TypeScript', updatedAt: '2026-04-20T00:00:00.000Z' }],
+  traits: [{ id: 2, content: 'Direct communicator', updatedAt: '2026-04-20T00:00:00.000Z' }],
+};
+
+beforeEach(() => {
+  localStorage.setItem(AUTH_TOKEN_KEY, 'test-token');
+  mockFetch.mockReset();
+});
+
+describe('usePersonalContext', () => {
+  it('starts loading with null data and no error', () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => usePersonalContext(vi.fn()));
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns data on success', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => mockData });
+    const { result } = renderHook(() => usePersonalContext(vi.fn()));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(mockData);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('calls onLogout on 401', async () => {
+    const onLogout = vi.fn();
+    mockFetch.mockResolvedValue({ ok: false, status: 401 });
+    renderHook(() => usePersonalContext(onLogout));
+    await waitFor(() => expect(onLogout).toHaveBeenCalledOnce());
+  });
+
+  it('sets an error on non-401 failures', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Server Error' });
+    const { result } = renderHook(() => usePersonalContext(vi.fn()));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toMatch(/failed to load personal context/i);
+    expect(result.current.data).toBeNull();
+  });
+
+  it('uses fallback error for non-Error rejections', async () => {
+    mockFetch.mockRejectedValue('broken');
+    const { result } = renderHook(() => usePersonalContext(vi.fn()));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBe('Failed to load personal context');
+  });
+
+  it('sends auth token in Authorization header', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => mockData });
+    renderHook(() => usePersonalContext(vi.fn()));
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledOnce());
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/dashboard/personal-context');
+    expect((options.headers as Record<string, string>)['Authorization']).toBe('Bearer test-token');
+  });
+});

--- a/packages/frontend/src/hooks/usePersonalContext.ts
+++ b/packages/frontend/src/hooks/usePersonalContext.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from 'react';
+import { AUTH_TOKEN_KEY } from '@/app.const';
+import { API_BASE_URL } from '@/config';
+import type { PersonalContextResponse } from '@/app.model';
+
+export interface UsePersonalContextReturn {
+  data: PersonalContextResponse | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function usePersonalContext(onLogout: () => void): UsePersonalContextReturn {
+  const [data, setData] = useState<PersonalContextResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const onLogoutRef = useRef(onLogout);
+  onLogoutRef.current = onLogout;
+
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    const fetchPersonalContext = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const token = localStorage.getItem(AUTH_TOKEN_KEY) ?? '';
+        const response = await fetch(`${API_BASE_URL}/dashboard/personal-context`, {
+          headers: { Authorization: `Bearer ${token}` },
+          signal: abortController.signal,
+        });
+
+        if (response.status === 401) {
+          onLogoutRef.current();
+          return;
+        }
+
+        if (!response.ok) {
+          throw new Error(`Failed to load personal context: ${response.statusText}`);
+        }
+
+        const json = (await response.json()) as PersonalContextResponse;
+        setData(json);
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          return;
+        }
+
+        setError(err instanceof Error ? err.message : 'Failed to load personal context');
+      } finally {
+        if (!abortController.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void fetchPersonalContext();
+
+    return () => {
+      abortController.abort();
+    };
+  }, []);
+
+  return { data, isLoading, error };
+}

--- a/packages/frontend/src/pages/PersonalContextPage.model.ts
+++ b/packages/frontend/src/pages/PersonalContextPage.model.ts
@@ -1,0 +1,3 @@
+export interface PersonalContextPageProps {
+  onLogout: () => void;
+}

--- a/packages/frontend/src/pages/PersonalContextPage.spec.tsx
+++ b/packages/frontend/src/pages/PersonalContextPage.spec.tsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { PersonalContextPage } from '@/pages/PersonalContextPage';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const fullData = {
+  memories: [{ id: 1, content: 'Prefers concise summaries', updatedAt: '2026-04-20T00:00:00.000Z' }],
+  traits: [{ id: 2, content: 'Strong systems thinker', updatedAt: '2026-04-19T00:00:00.000Z' }],
+};
+
+const emptyData = {
+  memories: [],
+  traits: [],
+};
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('PersonalContextPage', () => {
+  it('shows heading and renders fetched memories/traits', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => fullData });
+    render(<PersonalContextPage onLogout={vi.fn()} />);
+
+    expect(screen.getByRole('heading', { name: /your memory \+ traits/i })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Prefers concise summaries')).toBeInTheDocument());
+    expect(screen.getByText('Strong systems thinker')).toBeInTheDocument();
+  });
+
+  it('shows empty state messages when there is no data', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => emptyData });
+    render(<PersonalContextPage onLogout={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText(/does not have any memories about you yet/i)).toBeInTheDocument());
+    expect(screen.getByText(/does not have any core traits about you yet/i)).toBeInTheDocument();
+  });
+
+  it('shows an error banner when fetch fails', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error' });
+    render(<PersonalContextPage onLogout={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText(/failed to load personal context/i)).toBeInTheDocument());
+  });
+
+  it('calls onLogout when response is 401', async () => {
+    const onLogout = vi.fn();
+    mockFetch.mockResolvedValue({ ok: false, status: 401 });
+    render(<PersonalContextPage onLogout={onLogout} />);
+
+    await waitFor(() => expect(onLogout).toHaveBeenCalledOnce());
+  });
+});

--- a/packages/frontend/src/pages/PersonalContextPage.tsx
+++ b/packages/frontend/src/pages/PersonalContextPage.tsx
@@ -1,0 +1,117 @@
+import { AlertCircle, BookHeart, Sparkles } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { usePersonalContext } from '@/hooks/usePersonalContext';
+import type { PersonalContextEntry } from '@/app.model';
+import type { PersonalContextPageProps } from '@/pages/PersonalContextPage.model';
+
+function formatDateLabel(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function ContextList({
+  heading,
+  description,
+  emptyMessage,
+  entries,
+}: {
+  heading: string;
+  description: string;
+  emptyMessage: string;
+  entries: PersonalContextEntry[];
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{heading}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {entries.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+        ) : (
+          <ul className="space-y-3">
+            {entries.map((entry, index) => (
+              <li key={entry.id} className="rounded-md border bg-card/50 px-3 py-2">
+                <p className="text-sm leading-relaxed">
+                  <span className="font-semibold">{index + 1}. </span>
+                  {entry.content}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">Updated {formatDateLabel(entry.updatedAt)}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function PersonalContextPage({ onLogout }: PersonalContextPageProps) {
+  const { data, isLoading, error } = usePersonalContext(onLogout);
+
+  return (
+    <div className="p-8 max-w-6xl space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Your Memory + Traits</h1>
+        <p className="mt-2 text-muted-foreground">
+          See what Moonbeam remembers about you and which core traits it currently uses for personalization.
+        </p>
+      </div>
+
+      {error && (
+        <Card className="border-destructive/50">
+          <CardContent className="flex items-center gap-3 pt-6">
+            <AlertCircle className="h-5 w-5 text-destructive shrink-0" aria-hidden="true" />
+            <p className="text-sm text-destructive">{error}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {isLoading ? (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <BookHeart className="h-5 w-5" aria-hidden="true" />
+                Memories
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">Loading memories...</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Sparkles className="h-5 w-5" aria-hidden="true" />
+                Traits
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">Loading traits...</p>
+            </CardContent>
+          </Card>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <ContextList
+            heading="Memories"
+            description="Facts and context Moonbeam has extracted from your conversation history."
+            emptyMessage="Moonbeam does not have any memories about you yet."
+            entries={data?.memories ?? []}
+          />
+          <ContextList
+            heading="Traits"
+            description="Higher-level behavioral summaries inferred from your reinforced memories."
+            emptyMessage="Moonbeam does not have any core traits about you yet."
+            entries={data?.traits ?? []}
+          />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces a new "Personal Context" feature that allows users to view the memories and traits that the system has stored about them. The changes span both backend and frontend, including API endpoints, data models, UI components, and comprehensive tests.

**Key changes include:**

### Backend: API and Models

- **New API endpoint for personal context:**  
  Added a `/dashboard/personal-context` endpoint to the backend, which returns all memories and traits for the authenticated user. This endpoint aggregates data from the memory and trait persistence services and provides them in a unified response. [[1]](diffhunk://#diff-fc66b7e6e0af93eb5930a917fe6e42fee7112a2e36fb95db631f6b904dcb9c7aR9-R16) [[2]](diffhunk://#diff-fc66b7e6e0af93eb5930a917fe6e42fee7112a2e36fb95db631f6b904dcb9c7aR44-R75)

- **New data models for personal context:**  
  Introduced `PersonalContextEntry` and `PersonalContextResponse` interfaces to structure the memories and traits data returned by the new endpoint.

### Frontend: UI and State Management

- **Navigation and page integration:**  
  Added a new "Memories + Traits" page to the app shell navigation, complete with icon and routing logic. The navigation and page selection logic were updated to support this new page. [[1]](diffhunk://#diff-a35f2afddcfc3d54090ca3072a63c7c58528ffeb092ba7c3e0cdd18104aca0f6L3-R3) [[2]](diffhunk://#diff-7b5efbc88e629b98cc4c5440af345f1fc9d398dace47a292894ab5cc16c53746L2-R7) [[3]](diffhunk://#diff-7b5efbc88e629b98cc4c5440af345f1fc9d398dace47a292894ab5cc16c53746R46-R51) [[4]](diffhunk://#diff-7b5efbc88e629b98cc4c5440af345f1fc9d398dace47a292894ab5cc16c53746L57-R66)

- **Personal Context page and hook:**  
  Implemented `PersonalContextPage`, which fetches and displays the user's memories and traits. Created a custom React hook `usePersonalContext` to handle data fetching, loading, error states, and authentication handling. [[1]](diffhunk://#diff-9f0f6ea36fe28de0cde458ff04c3cb3508d6ca638a393fe4510b6081a1206f42R1-R117) [[2]](diffhunk://#diff-80cb573fdce9c9dc6460282c8f0ffcd8dbde35783a80e623c3997c3617e51078R1-R65) [[3]](diffhunk://#diff-6d9d3fb24ea0284a275ae1c282ef176d7f3f8f5b8e3c23fc1bfe5cde42200a03R1-R3)

- **Frontend models and data types:**  
  Mirrored the backend `PersonalContextEntry` and `PersonalContextResponse` types in the frontend model definitions for type safety and consistency.

### Testing

- **Comprehensive test coverage:**  
  Added tests for the new hook (`usePersonalContext`), the new page (`PersonalContextPage`), and navigation updates in the app shell to ensure correct rendering, error handling, and authentication flows. [[1]](diffhunk://#diff-15dbd87cd0a901d833a19030373ccf0abfdacb59c87152d01cd8f011458ff5eeR1-R65) [[2]](diffhunk://#diff-57769fc7224e77d4c94e5dbfc00ae0a0b9318eb3914a6055e1b35ac946cc8b31R1-R53) [[3]](diffhunk://#diff-eca602b06818c01d27928da0a6af3da11e84cce9fc9f352047402fa057ae4de9R32-R38)