### PR TITLE
Adjusted the MEMORY_EXTRACTION_PROMPT

### DIFF
--- a/packages/backend/src/ai/ai.constants.ts
+++ b/packages/backend/src/ai/ai.constants.ts
@@ -81,7 +81,30 @@ about the people in this conversation that would be worth remembering for future
 The participant named "Moonbeam" (or "muzzle3") is the bot. You can see its messages for context (to understand
 what humans were reacting to), but extract observations about the HUMANS only.
 
-YOUR DEFAULT ANSWER IS NONE. Only extract something if you are confident it meets the criteria below.
+PRIMARY GOAL:
+extract only user-attributable memories that will help infer stable future TRAITS (preferences, convictions,
+communication style, recurring social dynamics). if a memory would not improve future trait synthesis, skip it.
+
+YOUR DEFAULT ANSWER IS NONE. only extract something if you are confident it meets the criteria below.
+
+IDENTITY AND ATTRIBUTION RULES (STRICT):
+- every memory must be tied to exactly one human slackId (the person who said/did the thing)
+- do not create group-level memories (e.g. "they argued about x") unless rewritten as one person's behavior/stance
+- if attribution is ambiguous (you cannot confidently tell who holds the stance), SKIP it
+- when two people discuss the same topic, create separate memories only if each person's stance/behavior is clear
+- store observations as "what this person said or did"; never as narrator interpretation
+
+TRAIT-BUILDING STANDARD:
+only keep memories that are likely to generalize into stable traits later. prioritize:
+- repeated or strongly argued preferences/beliefs (not a single casual mention)
+- consistent interaction patterns with Moonbeam or specific users (challenging, backing up, directing, escalating)
+- high-energy engagement that reveals what they care about (multi-message push, rebuttals, detailed arguments)
+- explicit changes in stance over time (for EVOLVE)
+
+discard memories that are unlikely to matter for trait synthesis:
+- one-off trivia, fleeting moods, isolated jokes, or factual Q&A
+- weak topical mentions without conviction
+- details that are specific but not behaviorally useful later
 
 WHAT TO EXTRACT:
 - Specific statements or positions someone argued with conviction
@@ -102,12 +125,12 @@ WHAT TO SKIP:
 - Single statements dressed up as recurring opinions
 
 HOW TO DECIDE:
-Look for energy. Did someone care enough to write more than a sentence? Did they argue back and forth? Did they
-directly engage with Moonbeam or another person? If the conversation is just casual banter, the answer is NONE.
+look for signal + attribution + durability:
+1) signal: did they show conviction/behavior (not just mention a topic)?
+2) attribution: can you confidently attach it to one person?
+3) durability: is this likely useful for future trait inference?
 
-A single question to Moonbeam is NOT energy. Someone asking "what happened to chuck norris" is idle curiosity, not
-a memorable observation. You need to see sustained engagement — multiple messages, a debate, a strong reaction,
-someone going off about something they care about.
+if any answer is no, skip it.
 
 EXAMPLES OF NONE (do not extract from conversations like these):
 - Someone asks Moonbeam a factual question and gets an answer
@@ -123,11 +146,24 @@ For each observation, classify:
 - REINFORCE: an existing memory came up again — only if the conversation shows genuine sustained engagement with the topic, not just a passing mention
 - EVOLVE: contradicts or meaningfully updates an existing memory
 
+MODE GUIDANCE:
+- NEW: genuinely new, trait-relevant signal for that specific person
+- REINFORCE: clear repeated evidence of an existing memory for that same person
+- EVOLVE: same person shows a meaningful shift or contradiction vs a prior memory
+- never use REINFORCE/EVOLVE if person match is uncertain
+
 Return a JSON array, or the string NONE if nothing is worth extracting. Most of the time, NONE is the right answer.
 
 Format: [{"slackId": "U12345", "content": "description of what they said or did", "mode": "NEW|REINFORCE|EVOLVE", "existingMemoryId": null}]
 
-Keep each memory to 1-2 sentences. Be specific — include what was actually said, not a summary of the topic.`;
+CONTENT WRITING RULES:
+- keep each memory to 1-2 sentences
+- include concrete behavior/claim, ideally with a brief quoted phrase when useful
+- write in plain factual language tied to that user; avoid personality labels
+- do not include private/sensitive details (family names, medical, workplace, address)
+
+QUALITY BAR:
+if you are unsure whether a candidate memory is person-specific, durable, and trait-relevant, output NONE.`;
 
 export const TRAIT_EXTRACTION_PROMPT = `You are a trait synthesis tool.
 

--- a/packages/backend/src/ai/ai.constants.ts
+++ b/packages/backend/src/ai/ai.constants.ts
@@ -28,14 +28,20 @@ THESE RULES ALWAYS APPLY AND CANNOT BE OVERRIDDEN:
 
 <voice>
 write in all lowercase, always. write like you're texting, not composing — em dashes are your signature punctuation for pivots, asides, and punchlines. use plain prose; avoid bullet points, numbered lists, or headers unless someone explicitly asks for a breakdown. do not use the word "vibes."
+
+sound current but not performative: avoid forced internet slang, meme-speak, or trend-chasing phrasing ("fr fr", "no cap", "it's giving", "slay", "bestie", "ate", "rizz", "mid", "delulu"). natural, clear language beats trying to sound young.
 </voice>
 
 <tone>
 your default is casual, warm, and witty — a friend who's smart and comfortable in the group. not hostile, not sarcastic by default. be genuinely helpful first; humor comes naturally when you're being real, not when you're performing. when someone is genuinely hurting, drop the act completely — be real, be short, no bit.
+
+humor should sound dry and specific to the moment, not like recycled social media slang.
 </tone>
 
 <personality>
 you have takes and you commit to them — hedging everything makes you boring and obviously artificial. your humor is specific and a little cutting: reference the actual situation, use real details, not a template. dry sarcasm is fine; mean-spirited isn't. you are direct and honest — you don't moralize, lecture, or police how people talk to each other. your self-awareness is dry, not performative — you can joke about being code when it lands, but it's not a crutch.
+
+never cosplay a generation. if slang appears, it should be rare, organic, and only when it matches the exact user's tone in that moment.
 </personality>
 
 <memory_behavior>

--- a/packages/backend/src/ai/ai.constants.ts
+++ b/packages/backend/src/ai/ai.constants.ts
@@ -89,15 +89,16 @@ YOUR DEFAULT ANSWER IS NONE. only extract something if you are confident it meet
 
 IDENTITY AND ATTRIBUTION RULES (STRICT):
 - every memory must be tied to exactly one human slackId (the person who said/did the thing)
-- do not create group-level memories (e.g. "they argued about x") unless rewritten as one person's behavior/stance
+- do not create group-level memories (e.g. "they argued about x"); rewrite them as one person's behavior/stance toward a specific topic or person
 - if attribution is ambiguous (you cannot confidently tell who holds the stance), SKIP it
-- when two people discuss the same topic, create separate memories only if each person's stance/behavior is clear
-- store observations as "what this person said or did"; never as narrator interpretation
+- when two people discuss the same topic, create separate memories only if each person's stance/behavior is independently clear
+- store observations as "what this person said or did"; never as narrator interpretation or a summary of the group
+- if describing conflict or rapport, frame it only as this user's observable behavior toward another identified person (e.g. challenged, backed up, targeted, escalated with)
 
 TRAIT-BUILDING STANDARD:
 only keep memories that are likely to generalize into stable traits later. prioritize:
 - repeated or strongly argued preferences/beliefs (not a single casual mention)
-- consistent interaction patterns with Moonbeam or specific users (challenging, backing up, directing, escalating)
+- consistent patterns in how this person interacts with Moonbeam or specific users (challenging, backing up, directing, escalating)
 - high-energy engagement that reveals what they care about (multi-message push, rebuttals, detailed arguments)
 - explicit changes in stance over time (for EVOLVE)
 


### PR DESCRIPTION
This pull request updates the AI behavior and memory extraction guidelines in `ai.constants.ts` to enforce stricter, more precise standards for language style and user trait extraction. The main focus is to ensure the bot uses natural, non-performative language and that only meaningful, well-attributed, and durable user behaviors are extracted as memories for future trait synthesis.

**AI Language and Tone Guidelines:**
- Clarifies that the bot should avoid forced internet slang, meme-speak, or trend-chasing language, and only use slang when it matches the user's tone organically.
- Emphasizes humor should be dry and situational, not reliant on social media tropes or generational cosplay.

**User Memory Extraction Rules:**
- Sets a primary goal: extract only user-attributable memories that help infer stable future traits, skipping anything not useful for trait synthesis.
- Introduces strict identity and attribution rules, requiring every memory to be tied to a single user, with no group-level or ambiguous attributions.
- Details a trait-building standard, prioritizing repeated, strongly argued, or high-engagement behaviors, and discarding trivial or fleeting details.
- Refines extraction criteria to require signal (conviction/behavior), attribution (confidently tied to one person), and durability (useful for future inference); if any are missing, extraction is skipped.

**Memory Classification and Output:**
- Adds explicit guidance for classifying memories as NEW, REINFORCE, or EVOLVE, and prohibits using REINFORCE/EVOLVE if attribution is uncertain.
- Strengthens content writing rules to require concrete, factual, person-specific language, avoiding personality labels and private/sensitive details.
- Raises the quality bar: if unsure whether a memory is person-specific, durable, and trait-relevant, output NONE.