### PR TITLE
Fixed Bad Italics in Redeploy Message

### DIFF
--- a/packages/backend/src/ai/ai.service.spec.ts
+++ b/packages/backend/src/ai/ai.service.spec.ts
@@ -229,7 +229,7 @@ describe('AIService', () => {
         'Moonbeam has been deployed.',
         expect.arrayContaining([
           expect.objectContaining({ type: 'image', image_url: 'https://muzzle.lol/deploy.png' }),
-          expect.objectContaining({ type: 'markdown', text: '_"A quote"_' }),
+          expect.objectContaining({ type: 'markdown', text: '"A quote"' }),
           expect.objectContaining({ type: 'markdown', text: '*Release changelog*\n- tightened auth' }),
         ]),
       );

--- a/packages/backend/src/ai/ai.service.ts
+++ b/packages/backend/src/ai/ai.service.ts
@@ -254,7 +254,7 @@ export class AIService {
             image_url: imageUrl,
             alt_text: 'Moonbeam has been deployed.',
           },
-          ...(quote ? ([{ type: 'markdown', text: `_"${quote}"_` }] satisfies KnownBlock[]) : []),
+          ...(quote ? ([{ type: 'markdown', text: `"${quote}"` }] satisfies KnownBlock[]) : []),
           { type: 'divider' },
           {
             type: 'markdown',


### PR DESCRIPTION
This pull request makes a small adjustment to the formatting of quoted text in deployment notifications, removing the use of italics and underscores around quotes.

- Changed the formatting of the `quote` in deployment notifications from `_"quote"_` (italicized with underscores) to just `"quote"` (plain text in double quotes) in both the `AIService` implementation and its test. [[1]](diffhunk://#diff-b948ab5725b6fd8df14455c99a4eefb5b642b5c0798e3d9aa3581c18ab52ec7cL257-R257) [[2]](diffhunk://#diff-009267b50bda07d536a6fed9fa606b821506c63060869f1eb547d46dad2055f2L232-R232)