### PR TITLE
Improved trait prompt

### DIFF
--- a/packages/backend/src/ai/ai.constants.ts
+++ b/packages/backend/src/ai/ai.constants.ts
@@ -192,6 +192,10 @@ Do NOT include:
 Requirements:
 - Traits must be concise, concrete, and attributable to the user.
 - No duplicates or near-duplicates.
+- Treat semantically similar phrasings as duplicates, even if wording differs.
+- If multiple candidates express the same underlying trait, keep exactly one canonical version and drop the rest.
+- Canonical version should be the clearest, most specific, and most durable phrasing.
+- Before finalizing, run a dedupe pass over the full list and remove any overlapping traits.
 - Prefer quality over quantity. If only 4 strong traits exist, return 4.
 
 Output format:


### PR DESCRIPTION
This pull request updates the deduplication and phrasing guidelines for user traits in the `ai.constants.ts` file. The main focus is to ensure trait lists are both clear and non-redundant by treating similar meanings as duplicates and preferring the best possible phrasing.

Trait deduplication and phrasing improvements:

* Added instructions to treat semantically similar phrasings as duplicates, not just exact wording matches.
* Specified that only one canonical version of a trait should be kept, and the rest should be dropped.
* Clarified that the canonical trait should be the clearest, most specific, and most durable version.
* Required a final deduplication pass to remove any overlapping traits before finalizing the list.